### PR TITLE
Landscape support

### DIFF
--- a/harbour-phillis.pro
+++ b/harbour-phillis.pro
@@ -87,6 +87,7 @@ TRANSLATION_SOURCES += $$PWD/src
 TRANSLATIONS += translations/harbour-phillis.ts
 TRANSLATIONS += translations/harbour-phillis-it.ts
 TRANSLATIONS += translations/harbour-phillis-zh_CN.ts
+TRANSLATIONS += translations/harbour-phillis-fi.ts
 
 DISTFILES += $$TRANSLATIONS
 

--- a/qml/harbour-phillis.qml
+++ b/qml/harbour-phillis.qml
@@ -33,7 +33,7 @@ ApplicationWindow
     id: window
     cover: Qt.resolvedUrl("cover/CoverPage.qml")
     initialPage: Qt.resolvedUrl("pages/StartPage.qml")
-    allowedOrientations: defaultAllowedOrientations
+    allowedOrientations: Orientation.All
 
     property bool _pausedDueToDisplayState: false
     property var videoPlayerPage

--- a/qml/harbour-phillis.qml
+++ b/qml/harbour-phillis.qml
@@ -160,6 +160,12 @@ ApplicationWindow
     }
 
     ConfigurationValue {
+        id: settingDisplayVideosPerRow
+        defaultValue: 2
+        key: "/display/pornstars/items_per_grid_row"
+    }
+
+    ConfigurationValue {
         id: settingDisplayCategoriesPerRow
         defaultValue: 1
         key: "/display/categories/items_per_grid_row"

--- a/qml/harbour-phillis.qml
+++ b/qml/harbour-phillis.qml
@@ -178,6 +178,12 @@ ApplicationWindow
     }
 
     ConfigurationValue {
+        id: settingDisplayExtraLandscapeColumn
+        key: "/display/extra_landscape_column"
+        defaultValue: true
+    }
+
+    ConfigurationValue {
         id: settingPlaybackPauseInCoverMode
         key: "/playback/pause_in_cover_mode"
         defaultValue: false

--- a/qml/harbour-phillis.qml
+++ b/qml/harbour-phillis.qml
@@ -32,7 +32,9 @@ ApplicationWindow
 {
     id: window
     cover: Qt.resolvedUrl("cover/CoverPage.qml")
-    initialPage: Qt.resolvedUrl("pages/StartPage.qml")
+    initialPage: !disclaimerAccepted.value
+                 ? Qt.resolvedUrl("pages/AdultContentDisclaimerPage.qml")
+                 : Qt.resolvedUrl("pages/StartPage.qml")
     allowedOrientations: Orientation.All
 
     property bool _pausedDueToDisplayState: false
@@ -193,7 +195,7 @@ ApplicationWindow
         defaultValue: false
         onValueChanged: {
             if (value) {
-                pageStack.pop()
+                init()
             }
         }
     }
@@ -238,15 +240,13 @@ ApplicationWindow
     Component.onCompleted: {
         DownloadCache.cacheDirectory = StandardPaths.cache
 
-        if (!disclaimerAccepted.value) {
-            pageStack.push(Qt.resolvedUrl("pages/AdultContentDisclaimerPage.qml"), {}, PageStackAction.Immediate)
-        }
-
         if (restrictAccess) {
             pageStack.push(Qt.resolvedUrl("pages/LockScreenPage.qml"), {}, PageStackAction.Immediate)
         }
 
-        init()
+        if(disclaimerAccepted.value) {
+            init()
+        }
     }
 
     Component.onDestruction: {

--- a/qml/pages/AboutPage.qml
+++ b/qml/pages/AboutPage.qml
@@ -36,7 +36,11 @@ Page {
 
         Column {
             id: column
-            width: parent.width
+            anchors {
+                top: parent.top
+                horizontalCenter: parent.horizontalCenter
+            }
+            width: isPortrait ? parent.width : parent.width * 0.75
 
             PageHeader {
                 //% "About %1"

--- a/qml/pages/AboutPage.qml
+++ b/qml/pages/AboutPage.qml
@@ -26,6 +26,7 @@ import Sailfish.Silica 1.0
 import grumpycat 1.0
 
 Page {
+    allowedOrientations: Orientation.All
     SilicaFlickable {
         anchors.fill: parent
         contentWidth: parent.width

--- a/qml/pages/AdultContentDisclaimerPage.qml
+++ b/qml/pages/AdultContentDisclaimerPage.qml
@@ -37,9 +37,11 @@ Page {
 
         Column {
             id: column
-            x: Theme.horizontalPageMargin
-            width: parent.width - 2*x
-            anchors.verticalCenter: parent.verticalCenter
+            anchors {
+                top: parent.top
+                horizontalCenter: parent.horizontalCenter
+            }
+            width: isPortrait ? parent.width * 0.9 : parent.width * 0.6
             spacing: 2*Theme.paddingMedium
 
             Item {

--- a/qml/pages/AdultContentDisclaimerPage.qml
+++ b/qml/pages/AdultContentDisclaimerPage.qml
@@ -26,6 +26,7 @@ import Sailfish.Silica 1.0
 
 
 Page {
+    allowedOrientations: Orientation.All
     backNavigation: false
     SilicaFlickable {
         anchors.fill: parent

--- a/qml/pages/AdultContentDisclaimerPage.qml
+++ b/qml/pages/AdultContentDisclaimerPage.qml
@@ -99,7 +99,10 @@ Page {
                     anchors.horizontalCenter: parent.horizontalCenter
                     //% "Accept"
                     text: qsTrId("ph-disclaimer-page-accept-button")
-                    onClicked: disclaimerAccepted.value = true
+                    onClicked: {
+                        disclaimerAccepted.value = true
+                        pageStack.replace(Qt.resolvedUrl("StartPage.qml"))
+                    }
                 }
             }
 

--- a/qml/pages/CategoriesPage.qml
+++ b/qml/pages/CategoriesPage.qml
@@ -28,6 +28,7 @@ import ".."
 
 Page {
     id: root
+    allowedOrientations: Orientation.All
 
     property bool _reload: false
     property string prefix

--- a/qml/pages/CategoriesPage.qml
+++ b/qml/pages/CategoriesPage.qml
@@ -34,9 +34,10 @@ Page {
     property string prefix
     property string categoriesUrl
     property string title
+    readonly property bool useExtraRow: settingDisplayExtraLandscapeColumn.value
     readonly property int itemPerRow: settingDisplayCategoriesPerRow.value
     property real _targetImageHeight: Theme.itemSizeHuge
-    readonly property real _targetCellWidth: width / itemPerRow
+    readonly property real _targetCellWidth: width / (itemPerRow + (isLandscape && useExtraRow ? 1 : 0))
     property bool _thumbnailLoaded: false
     property var _filter: new RegExp(".*")
     property var _categories: []

--- a/qml/pages/LockScreenPage.qml
+++ b/qml/pages/LockScreenPage.qml
@@ -26,6 +26,7 @@ import Sailfish.Silica 1.0
 
 
 Page {
+    allowedOrientations: Orientation.All
     readonly property bool isLockScreenPage: true
     backNavigation: false
     property bool _pausedVideo: false

--- a/qml/pages/PornstarsPage.qml
+++ b/qml/pages/PornstarsPage.qml
@@ -34,9 +34,10 @@ Page {
     property string title
     property bool _reload: false
     property int _page: 0
+    readonly property bool useExtraRow: settingDisplayExtraLandscapeColumn.value
     readonly property int itemPerRow: settingDisplayPornstarsPerRow.value
     property real _targetImageHeight: Theme.itemSizeHuge
-    readonly property real _targetCellWidth: width / itemPerRow
+    readonly property real _targetCellWidth: width / (itemPerRow + (isLandscape && useExtraRow ? 1 : 0))
     property bool _thumbnailLoaded: false
     property var _pornstars: []
     property bool isSearch: false

--- a/qml/pages/PornstarsPage.qml
+++ b/qml/pages/PornstarsPage.qml
@@ -28,6 +28,7 @@ import ".."
 
 Page {
     id: root
+    allowedOrientations: Orientation.All
 
     property string pornstarsUrl
     property string title

--- a/qml/pages/RecommendedPage.qml
+++ b/qml/pages/RecommendedPage.qml
@@ -28,6 +28,7 @@ import ".."
 
 Page {
     id: root
+    allowedOrientations: Orientation.All
 
     property bool _reload: false
 //    readonly property int pornstarsPerRow: settingDisplayPornstarsPerRow.value

--- a/qml/pages/SettingsPage.qml
+++ b/qml/pages/SettingsPage.qml
@@ -178,6 +178,31 @@ Page {
             TextField {
                 width: parent.width
                 inputMethodHints: Qt.ImhFormattedNumbersOnly
+                //% "Videos per row"
+                label: qsTrId("ph-settings-page-display-videos-per-grid-row")
+                text: settingDisplayVideosPerRow.value
+                EnterKey.enabled: acceptableInput
+                EnterKey.iconSource: "image://theme/icon-m-enter-close"
+                EnterKey.onClicked: focus = false
+                validator: IntValidator {
+                    bottom: 1
+                }
+
+                onTextChanged: {
+                    console.debug("text: " + text)
+                    if (acceptableInput) {
+                        var number = parseFloat(text)
+                        console.debug("number: " + number)
+                        if (typeof(number) === "number") {
+                            settingDisplayVideosPerRow.value = number
+                        }
+                    }
+                }
+            }
+
+            TextField {
+                width: parent.width
+                inputMethodHints: Qt.ImhFormattedNumbersOnly
                 //% "Categories per row"
                 label: qsTrId("ph-settings-page-display-categories-per-grid-row")
                 text: settingDisplayCategoriesPerRow.value

--- a/qml/pages/SettingsPage.qml
+++ b/qml/pages/SettingsPage.qml
@@ -250,6 +250,16 @@ Page {
                 }
             }
 
+            TextSwitch {
+                //% "Add one extra column in landscape orientation"
+                text: qsTrId("ph-settings-page-display-extra-landscape-column")
+                checked: settingDisplayExtraLandscapeColumn.value
+                onClicked: {
+                    settingDisplayExtraLandscapeColumn.value = !settingDisplayExtraLandscapeColumn.value
+                    console.debug("display extra landscape column=" + checked)
+                }
+            }
+
             SectionHeader {
                 //% "Access"
                 text: qsTrId("ph-settings-page-access")

--- a/qml/pages/SettingsPage.qml
+++ b/qml/pages/SettingsPage.qml
@@ -191,7 +191,7 @@ Page {
                 onTextChanged: {
                     console.debug("text: " + text)
                     if (acceptableInput) {
-                        var number = parseFloat(text)
+                        var number = parseInt(text)
                         console.debug("number: " + number)
                         if (typeof(number) === "number") {
                             settingDisplayVideosPerRow.value = number
@@ -216,7 +216,7 @@ Page {
                 onTextChanged: {
                     console.debug("text: " + text)
                     if (acceptableInput) {
-                        var number = parseFloat(text)
+                        var number = parseInt(text)
                         console.debug("number: " + number)
                         if (typeof(number) === "number") {
                             settingDisplayCategoriesPerRow.value = number
@@ -241,7 +241,7 @@ Page {
                 onTextChanged: {
                     console.debug("text: " + text)
                     if (acceptableInput) {
-                        var number = parseFloat(text)
+                        var number = parseInt(text)
                         console.debug("number: " + number)
                         if (typeof(number) === "number") {
                             settingDisplayPornstarsPerRow.value = number

--- a/qml/pages/SettingsPage.qml
+++ b/qml/pages/SettingsPage.qml
@@ -29,6 +29,7 @@ import ".."
 
 Page {
     id: root
+    allowedOrientations: Orientation.All
 
     SilicaFlickable {
         anchors.fill: parent

--- a/qml/pages/SettingsPage.qml
+++ b/qml/pages/SettingsPage.qml
@@ -40,7 +40,11 @@ Page {
 
         Column {
             id: column
-            width: parent.width
+            anchors {
+                top: parent.top
+                horizontalCenter: parent.horizontalCenter
+            }
+            width: isPortrait ? parent.width : parent.width * 0.75
 
             PageHeader {
                 id: header
@@ -172,7 +176,7 @@ Page {
             }
 
             TextField {
-                width: root.width
+                width: parent.width
                 inputMethodHints: Qt.ImhFormattedNumbersOnly
                 //% "Categories per row"
                 label: qsTrId("ph-settings-page-display-categories-per-grid-row")
@@ -197,7 +201,7 @@ Page {
             }
 
             TextField {
-                width: root.width
+                width: parent.width
                 inputMethodHints: Qt.ImhFormattedNumbersOnly
                 //% "Pornstars per row"
                 label: qsTrId("ph-settings-page-display-pornstars-per-grid-row")
@@ -242,7 +246,7 @@ Page {
 
             TextField {
                 id: pinField
-                width: root.width
+                width: parent.width
                 enabled: settingAccessRestrict.value
                 inputMethodHints: Qt.ImhFormattedNumbersOnly
                 //% "PIN"
@@ -260,7 +264,7 @@ Page {
             }
 
             TextField {
-                width: root.width
+                width: parent.width
                 enabled: settingAccessRestrict.value
                 //% "Lock screen text"
                 label: qsTrId("ph-settings-page-access-lock-screen-text")

--- a/qml/pages/StartPage.qml
+++ b/qml/pages/StartPage.qml
@@ -28,6 +28,7 @@ import ".."
 
 Page {
     id: root
+    allowedOrientations: Orientation.All
 
     readonly property string categoriesUrl: Constants.baseUrl + "/categories"
     readonly property string prefix: settingGayOnly.value ? "/gay" : ""

--- a/qml/pages/StartPage.qml
+++ b/qml/pages/StartPage.qml
@@ -186,7 +186,11 @@ Page {
 
         Column {
             id: column
-            width: parent.width
+            anchors {
+                top: parent.top
+                horizontalCenter: parent.horizontalCenter
+            }
+            width: isPortrait ? parent.width : parent.width * 0.75
 
             PageHeader {
                 //% "Pornhub"

--- a/qml/pages/TranslationsPage.qml
+++ b/qml/pages/TranslationsPage.qml
@@ -35,7 +35,11 @@ Page {
 
         Column {
             id: column
-            width: parent.width
+            anchors {
+                top: parent.top
+                horizontalCenter: parent.horizontalCenter
+            }
+            width: isPortrait ? parent.width : parent.width * 0.75
 
             PageHeader {
                 //% "Translations"

--- a/qml/pages/TranslationsPage.qml
+++ b/qml/pages/TranslationsPage.qml
@@ -25,6 +25,7 @@ import QtQuick 2.0
 import Sailfish.Silica 1.0
 
 Page {
+    allowedOrientations: Orientation.All
     SilicaFlickable {
         anchors.fill: parent
         contentWidth: parent.width

--- a/qml/pages/TranslationsPage.qml
+++ b/qml/pages/TranslationsPage.qml
@@ -73,6 +73,12 @@ Page {
                         value: "fravaccaro"
                     }
 
+                    DetailItem {
+                        //% "Finnish"
+                        label: qsTrId("ph-translations-page-finnish-label")
+                        value: "direc85"
+                    }
+
                     Item {
                         width: parent.width
                         height: Theme.paddingLarge

--- a/qml/pages/VideosPage.qml
+++ b/qml/pages/VideosPage.qml
@@ -28,6 +28,7 @@ import ".."
 
 Page {
     id: root
+    allowedOrientations: Orientation.All
 
     property string videosUrl
     property string title

--- a/qml/pages/VideosPage.qml
+++ b/qml/pages/VideosPage.qml
@@ -32,6 +32,8 @@ Page {
 
     property string videosUrl
     property string title
+    readonly property int itemPerRow: settingDisplayVideosPerRow.value
+    readonly property real _targetCellWidth: width / itemPerRow
     property bool _reload: false
     property int _page: 0
     readonly property int videosToSkip: 4
@@ -96,10 +98,13 @@ Page {
             }
         }
 
-        SilicaListView {
+        SilicaGridView {
             id: view
             anchors.fill: parent
             model: model
+
+            cellWidth: _targetCellWidth
+            cellHeight: cellWidth * 9 / 16
 
             header: PageHeader {
                 id: header
@@ -110,8 +115,8 @@ Page {
             delegate: Component {
                 ListItem {
                     id: videoItem
-                    contentHeight: thumbnail.height
-                    width: ListView.view.width
+                    width: view.cellWidth
+                    height: view.cellHeight
                     enabled: !_startedMetaDataDownload
 
                     property var _playlist
@@ -178,7 +183,7 @@ Page {
                     }
 
                     onClicked: {
-                        ListView.view.currentIndex = index
+                        view.currentIndex = index
                         pageStack.push(Qt.resolvedUrl("VideoPlayerPage.qml"), {
                                                         videoId: video_id,
                                                         videoUrl: video_url,

--- a/qml/pages/VideosPage.qml
+++ b/qml/pages/VideosPage.qml
@@ -32,8 +32,9 @@ Page {
 
     property string videosUrl
     property string title
+    readonly property bool useExtraRow: settingDisplayExtraLandscapeColumn.value
     readonly property int itemPerRow: settingDisplayVideosPerRow.value
-    readonly property real _targetCellWidth: width / itemPerRow
+    readonly property real _targetCellWidth: width / (itemPerRow + (isLandscape && useExtraRow ? 1 : 0))
     property bool _reload: false
     property int _page: 0
     readonly property int videosToSkip: 4

--- a/translations/harbour-phillis-fi.ts
+++ b/translations/harbour-phillis-fi.ts
@@ -1,122 +1,122 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="it">
+<TS version="2.1" language="fi_FI">
 <context>
     <name></name>
     <message id="ph-settings-page-header">
         <location filename="../qml/pages/SettingsPage.qml" line="52"/>
         <source>Settings</source>
-        <translation>Impostazioni</translation>
+        <translation>Asetukset</translation>
     </message>
     <message id="ph-settings-page-network-header">
         <location filename="../qml/pages/SettingsPage.qml" line="57"/>
         <source>Network</source>
-        <translation>Rete</translation>
+        <translation>Verkko</translation>
     </message>
     <message id="ph-settings-page-network-connection-type">
         <location filename="../qml/pages/SettingsPage.qml" line="64"/>
         <source>Network connection type</source>
-        <translation>Tipo connessione di rete</translation>
+        <translation>Yhteystyyppi</translation>
     </message>
     <message id="ph-settings-page-network-connection-autodetect">
         <location filename="../qml/pages/SettingsPage.qml" line="68"/>
         <source>Autodetect</source>
-        <translation>Automatico</translation>
+        <translation>Tunnista automaattisesti</translation>
     </message>
     <message id="ph-settings-page-network-connection-broadband">
         <location filename="../qml/pages/SettingsPage.qml" line="72"/>
         <source>Broadband</source>
-        <translation>Broadband</translation>
+        <translation>Laajakaistayhteys</translation>
     </message>
     <message id="ph-settings-page-network-connection-mobile">
         <location filename="../qml/pages/SettingsPage.qml" line="76"/>
         <source>Mobile</source>
-        <translation>Mobile</translation>
+        <translation>Matkapuhelinverkkoyhteys</translation>
     </message>
     <message id="ph-format-label">
         <location filename="../qml/pages/SettingsPage.qml" line="90"/>
         <source>Format</source>
-        <translation>Formato</translation>
+        <translation>Laatuasetukset</translation>
     </message>
     <message id="ph-settings-page-network-broadband-label">
         <location filename="../qml/pages/SettingsPage.qml" line="95"/>
         <source>Broadband</source>
-        <translation>Broadband</translation>
+        <translation>Laajakaistayhteys</translation>
     </message>
     <message id="ph-settings-page-network-mobile-label">
         <location filename="../qml/pages/SettingsPage.qml" line="109"/>
         <source>Mobile</source>
-        <translation>Mobile</translation>
+        <translation>Matkapuhelinverkkoyhteys</translation>
     </message>
     <message id="ph-settings-page-content-preferences-section-header">
         <location filename="../qml/pages/SettingsPage.qml" line="123"/>
         <source>Content Preferences</source>
-        <translation>Preferenze contenuto</translation>
+        <translation>Sisältöasetukset</translation>
     </message>
     <message id="ph-settings-page-content-preferences-gay-only-switch-text">
         <location filename="../qml/pages/SettingsPage.qml" line="132"/>
         <source>Gay Only</source>
-        <translation>Solo gay</translation>
+        <translation>Vain homo- ja lesbosisältö</translation>
     </message>
     <message id="ph-settings-page-content-preferences-gay-only-switch-description">
         <location filename="../qml/pages/SettingsPage.qml" line="134"/>
         <source>Only show gay categories and videos</source>
-        <translation>Mostra solo categorie e video gay</translation>
+        <translation>Näytä vain homo- ja lesbovideot ja kategoriat</translation>
     </message>
     <message id="ph-settings-page-playback-section-header">
         <location filename="../qml/pages/SettingsPage.qml" line="150"/>
         <source>Playback</source>
-        <translation>Riproduzione</translation>
+        <translation>Toistaminen</translation>
     </message>
     <message id="ph-settings-page-playback-pause-on-device-lock-switch">
         <location filename="../qml/pages/SettingsPage.qml" line="155"/>
         <source>Pause playback on device lock</source>
-        <translation>Metti in pausa al blocco del dispositivo</translation>
+        <translation>Keskeytä video kun laite lukitaan</translation>
     </message>
     <message id="ph-settings-page-playback-pause-if-cover-page-switch">
         <location filename="../qml/pages/SettingsPage.qml" line="165"/>
         <source>Pause playback when the cover page is shown</source>
-        <translation>Metti in pausa quando minimizzato nella cover</translation>
+        <translation>Keskeytä video kun sovellus pienennetään</translation>
     </message>
     <message id="ph-settings-page-display">
         <location filename="../qml/pages/SettingsPage.qml" line="175"/>
         <source>Display</source>
-        <translation>Mostra</translation>
+        <translation>Ulkoasu</translation>
     </message>
     <message id="ph-settings-page-display-videos-per-grid-row">
         <location filename="../qml/pages/SettingsPage.qml" line="182"/>
         <source>Videos per row</source>
-        <translation type="unfinished"></translation>
+        <translation>Videosarakkeiden määrä</translation>
     </message>
     <message id="ph-settings-page-display-categories-per-grid-row">
         <location filename="../qml/pages/SettingsPage.qml" line="207"/>
         <source>Categories per row</source>
-        <translation>Categorie per riga</translation>
+        <translation>Kategoriasarakkeiden määrä</translation>
     </message>
     <message id="ph-settings-page-display-pornstars-per-grid-row">
         <location filename="../qml/pages/SettingsPage.qml" line="232"/>
         <source>Pornstars per row</source>
-        <translation>Pornostar per riga</translation>
+        <translation>Pornotähtisarakkeiden määrä</translation>
     </message>
     <message id="ph-settings-page-display-extra-landscape-column">
         <location filename="../qml/pages/SettingsPage.qml" line="255"/>
         <source>Add one extra column in landscape orientation</source>
-        <translation type="unfinished"></translation>
+        <translation>Näytä yksi sarake enemmän vaakatilassa</translation>
     </message>
     <message id="ph-settings-page-access">
         <location filename="../qml/pages/SettingsPage.qml" line="265"/>
         <source>Access</source>
-        <translation>Accesso</translation>
+        <translation>Suojaus</translation>
     </message>
     <message id="ph-settings-page-access-restrict-text">
         <location filename="../qml/pages/SettingsPage.qml" line="270"/>
         <source>Require a PIN to access the app</source>
-        <translation>Richiedi un PIN per accedere all&apos;app</translation>
+        <translation>Vaadi PIN-koodi sovelluksen käynnistämiseen</translation>
     </message>
     <message id="ph-settings-page-access-restrict-description">
         <location filename="../qml/pages/SettingsPage.qml" line="272"/>
         <source>Protect against accidently accessing the application. The PIN will be stored as plain text in the application configuration directory. Should you forget your PIN simply delete the file to restore access to the application.</source>
-        <translation>Proteggi contro l&apos;accesso accidentale all&apos;app. Il PIN sarà salvato come file di testo nella cartella di configurazione dell&apos;app, per cui nel caso dovessi dimenticarlo ti basterà cancellare quel file per ripristinare l&apos;accesso all&apos;app.</translation>
+        <translation>Suojaa sovellus epähuomiossa käynnistämisen varalta. PIN-koodi tallennetaan selväkielisenä ohjelman asetustiedostoon. Jos unohdat koodin, voit palauttaa pääsyn sovellukseen poistamalla asetustiedoston.</translation>
     </message>
     <message id="ph-settings-page-access-require-pin-label">
         <location filename="../qml/pages/SettingsPage.qml" line="288"/>
@@ -126,32 +126,32 @@
     <message id="ph-settings-page-access-require-pin-placeholder">
         <location filename="../qml/pages/SettingsPage.qml" line="290"/>
         <source>Enter four or more digits</source>
-        <translation>Inserisci almeno quattro cifre</translation>
+        <translation>Syötä vähintään neljä numeroa</translation>
     </message>
     <message id="ph-settings-page-access-lock-screen-text">
         <location filename="../qml/pages/SettingsPage.qml" line="305"/>
         <source>Lock screen text</source>
-        <translation>Testo blocco schermo</translation>
+        <translation>Lukitusruudun teksti</translation>
     </message>
     <message id="ph-settings-page-account">
         <location filename="../qml/pages/SettingsPage.qml" line="318"/>
         <source>Account</source>
-        <translation>Account</translation>
+        <translation>Tilitiedot</translation>
     </message>
     <message id="ph-settings-page-account-username">
         <location filename="../qml/pages/SettingsPage.qml" line="323"/>
         <source>Username</source>
-        <translation>Nome utente</translation>
+        <translation>Käyttäjänimi</translation>
     </message>
     <message id="ph-settings-page-account-auto-login">
         <location filename="../qml/pages/SettingsPage.qml" line="349"/>
         <source>Login on application start</source>
-        <translation>Accedi all&apos;avvio dell&apos;app</translation>
+        <translation>Kirjaudu automaattisesti</translation>
     </message>
     <message id="ph-about-page-header">
         <location filename="../qml/pages/AboutPage.qml" line="47"/>
         <source>About %1</source>
-        <translation>Info su %1</translation>
+        <translation>Tietoja sovelluksesta %1</translation>
     </message>
     <message id="ph-about-page-version-text">
         <location filename="../qml/pages/AboutPage.qml" line="95"/>
@@ -161,105 +161,105 @@
     <message id="ph-about-page-description-header">
         <location filename="../qml/pages/AboutPage.qml" line="112"/>
         <source>Description</source>
-        <translation>Descrizione</translation>
+        <translation>Kuvaus</translation>
     </message>
     <message id="ph-about-page-description-text">
         <location filename="../qml/pages/AboutPage.qml" line="119"/>
         <source>%1 is an unofficial Sailfish OS client for the adult content website &lt;a href=&apos;https://www.pornhub.com/&apos;&gt;Pornhub&lt;/a&gt;.</source>
-        <translation>%1 è un client non ufficiale Sailfish OS del sito web per adulti &lt;a href=&apos;https://www.pornhub.com/&apos;&gt;Pornhub&lt;/a&gt;.</translation>
+        <translation>%1 on epävirallinen SailfishOS-sovellus aikuisviihdesivuston &lt;a href=&apos;https://www.pornhub.com/&apos;&gt;Pornhub&lt;/a&gt; sisällön käyttämiseen.</translation>
     </message>
     <message id="about-page-disclaimer-header">
         <location filename="../qml/pages/AboutPage.qml" line="128"/>
         <source>Disclaimer</source>
-        <translation>Esclusione della responsabilità</translation>
+        <translation>Vastuuvapauslauseke</translation>
     </message>
     <message id="ph-about-page-disclaimer-text">
         <location filename="../qml/pages/AboutPage.qml" line="135"/>
         <source>The content provided through %1 is the property and sole responsibility of &lt;a href=&apos;https://www.pornhub.com/&apos;&gt;Pornhub&lt;/a&gt;.</source>
-        <translation>Il contenuto fruito attraverso %1 è proprietà e responsabilità di &lt;a href=&apos;https://www.pornhub.com/&apos;&gt;Pornhub&lt;/a&gt;.</translation>
+        <translation>Kaikki materiaali, jota sovelluksen %1 avulla voi käyttää, on &lt;a href=&apos;https://www.pornhub.com/&apos;&gt;Pornhub&lt;/a&gt;-sivuston omaisuutta sekä vastuulla.</translation>
     </message>
     <message id="about-page-credits-licenses-sources-header">
         <location filename="../qml/pages/AboutPage.qml" line="144"/>
         <source>Credits, Licenses, and Sources</source>
-        <translation>Crediti, licenze e sorgenti</translation>
+        <translation>Tekijät, lisenssi ja lähdekoodi</translation>
     </message>
     <message id="ph-about-page-credits-licenses-sources-text">
         <location filename="../qml/pages/AboutPage.qml" line="151"/>
         <source>Copyright © 2019 grumpycat&lt;br/&gt;&lt;br/&gt;This application is available under the MIT licence on &lt;a href=&apos;https://github.com/grumpycat3051/harbour-phillis/&apos;&gt;Github&lt;/a&gt;. %1 uses icons made by Smashicons from &lt;a href=&apos;https://www.flaticon.com/&apos;&gt;flaticon&lt;/a&gt;.</source>
         <oldsource>Copyright © 2019 grumpycat&lt;br/&gt;&lt;br/&gt;This application is available under the MIT licence on &lt;a href=&apos;https://github.com/grumpycat3051/harbour-phillis/&apos;&gt;Github&lt;/a&gt;.&lt;br/&gt;%1 uses icons made by Smashicons from &lt;a href=&apos;https://www.flaticon.com/&apos;&gt;flaticon&lt;/a&gt;.</oldsource>
-        <translation>Copyright © 2019 grumpycat&lt;br/&gt;&lt;br/&gt;Quest&apos;app è rilasciata sotto licenza MIT su &lt;a href=&apos;https://github.com/grumpycat3051/harbour-phillis/&apos;&gt;Github&lt;/a&gt;. %1 utilizza le icone di Smashicons da &lt;a href=&apos;https://www.flaticon.com/&apos;&gt;flaticon&lt;/a&gt;.</translation>
+        <translation>Copyright © 2019 grumpycat&lt;br/&gt;&lt;br/&gt;Tämä sovellus on julkaistu MIT-lisenssin alla &lt;a href=&apos;https://github.com/grumpycat3051/harbour-phillis/&apos;&gt;Github&lt;/a&gt;-sivustolla. %1 käyttää Smashiconsin tekemiä ikoneita sivustolta &lt;a href=&apos;https://www.flaticon.com/&apos;&gt;flaticon&lt;/a&gt;.</translation>
     </message>
     <message id="ph-about-privacy-header">
         <location filename="../qml/pages/AboutPage.qml" line="173"/>
         <source>Privacy</source>
-        <translation>Privacy</translation>
+        <translation>Yksityisyydensuoja</translation>
     </message>
     <message id="ph-about-page-privacy-text">
         <location filename="../qml/pages/AboutPage.qml" line="180"/>
         <source>This application does not collect or save any personal data aside from possibly those credentials required to sign into &lt;a href=&apos;https://www.pornhub.com/&apos;&gt;Pornhub&lt;/a&gt;.</source>
-        <translation>Quest&apos;app non salva né raccoglie nessun dato personale. Se effettui l&apos;accesso, l&apos;app salverà le credenziali di &lt;a href=&apos;https://www.pornhub.com/&apos;&gt;Pornhub&lt;/a&gt;.</translation>
+        <translation>Tämä sovellus ei tallenna tai kerää mitään tietoja käyttäjästään, poislukien käyttäjän itsensä syöttämät &lt;a href=&apos;https://www.pornhub.com/&apos;&gt;Pornhub&lt;/a&gt;-sivuston käyttäjätunnus sekä salasana, jotka vaaditaan palveluun kirjautumiseen.</translation>
     </message>
     <message id="about-page-translations-button">
         <location filename="../qml/pages/AboutPage.qml" line="166"/>
         <source>Translations</source>
-        <translation>Traduzioni</translation>
+        <translation>Käännökset</translation>
     </message>
     <message id="ph-categories-page-filter-placeholder">
         <location filename="../qml/pages/CategoriesPage.qml" line="117"/>
         <source>Filter</source>
-        <translation>Filtri</translation>
+        <translation>Suodata</translation>
     </message>
     <message id="ph-categories-page-view-placeholder-text-loading">
         <location filename="../qml/pages/CategoriesPage.qml" line="205"/>
         <source>Categories are being loaded</source>
-        <translation>Caricamento categorie</translation>
+        <translation>Kategorioita ladataan</translation>
     </message>
     <message id="ph-push-up-menu-load-more">
         <location filename="../qml/pages/PornstarsPage.qml" line="116"/>
         <location filename="../qml/pages/VideosPage.qml" line="97"/>
         <source>Load more</source>
-        <translation>Carica altro</translation>
+        <translation>Lataa lisää kohteita</translation>
     </message>
     <message id="ph-pornstars-page-view-placeholder-text-loading">
         <location filename="../qml/pages/PornstarsPage.qml" line="174"/>
         <source>Pornstars are being loaded</source>
-        <translation>Caricamento pornostar</translation>
+        <translation>Pornotähtiä ladataan</translation>
     </message>
     <message id="ph-view-placeholder-text-no-results">
         <location filename="../qml/pages/PornstarsPage.qml" line="179"/>
         <location filename="../qml/pages/VideosPage.qml" line="207"/>
         <source>Search yielded no results</source>
-        <translation>La ricerca non ha fornito risultati</translation>
+        <translation>Ei hakutuloksia</translation>
     </message>
     <message id="ph-videos-page-context-menu-copy-url-to-clipboard">
         <location filename="../qml/pages/VideosPage.qml" line="130"/>
         <source>Copy URL to clipboard</source>
-        <translation>Copia URL negli appunti</translation>
+        <translation>Kopioi URL leikepöydälle</translation>
     </message>
     <message id="ph-videos-page-view-placeholder-text-loading">
         <location filename="../qml/pages/VideosPage.qml" line="202"/>
         <source>Videos are being loaded</source>
-        <translation>Caricamento video</translation>
+        <translation>Videoita ladataan</translation>
     </message>
     <message id="ph-disclaimer-page-title">
         <location filename="../qml/pages/AdultContentDisclaimerPage.qml" line="60"/>
         <source>Adult Content Disclaimer</source>
-        <translation>Clausola di esclusione della responsabilità</translation>
+        <translation>Aikuisviihdesisällön vastuuvapauslauseke</translation>
     </message>
     <message id="ph-disclaimer-page-text1">
         <location filename="../qml/pages/AdultContentDisclaimerPage.qml" line="73"/>
         <source>The content provided through this app is designed for ADULTS only and may include pictures and materials that some viewers may find offensive. If you are under the age of 18, if such material offends you or if it is illegal to view such material in your community please exit the site. The following terms and conditions apply to this site. Use of the site will constitute your agreement to the following terms and conditions:</source>
-        <translation>Il contenuto fruito attraverso quest&apos;app è destinato soltanto ad ADULTI e potrebbe includere immagini e materiale che alcuni utenti potrebbero trovare offensivo. Se sei minorenne, se questo materiale ti offende o se ti trovi in paesi nei quali guardare questo materiale è illegale, esci da questo sito. L&apos;utilizzo del sito costituisce l&apos;accettazione dei seguenti termini e condizioni:</translation>
+        <translation>Sisältö, jota tämän sovelluksen avulla voi tarkastella, on tarkoitettu VAIN AIKUISILLE ja saattaa sisältää kuvia ja materiaalia, jotka saattavat loukata joitakin sisällön katsojia. Jos olet alle 18-vuotias, jos jokin sisältö loukkaa sinua tai jos maassasi tai yhteisössäsi on luvatonta tai lainvastaista tarkastella kyseistä materiaalia, älä käytä tätä sovellusta. Seuraavat käyttöehdot koskevat tätä sovellusta ja sivustoa. Sovelluksen ja sivuston käyttö edellyttää että hyväksyt seuraavat käyttöehdot:</translation>
     </message>
     <message id="ph-disclaimer-page-text2">
         <location filename="../qml/pages/AdultContentDisclaimerPage.qml" line="86"/>
         <source>1.) I am 18 years of age or older&lt;br/&gt;2.) I accept all responsibility for my own actions; and&lt;br/&gt;3.) I agree that I am legally bound to these Terms and Conditions</source>
-        <translation>1) Sono maggiorenne&lt;br/&gt;2) Accetto la responsabilità delle mie azioni&lt;br/&gt;3) Accetto che questi termini e condizioni abbiano valore legale</translation>
+        <translation>1) Olen vähintään 18-vuotias&lt;br/&gt;2) Hyväksyn olevani itse vastuussa omista teoistani&lt;br/&gt;3) Hyväksyn että olen sitoutunut näihin käyttöehtoihin lainmukaisesti</translation>
     </message>
     <message id="ph-disclaimer-page-accept-button">
         <location filename="../qml/pages/AdultContentDisclaimerPage.qml" line="101"/>
         <source>Accept</source>
-        <translation>Accetto</translation>
+        <translation>Hyväksy</translation>
     </message>
     <message id="ph-lock-screen-page-pin-placeholder">
         <location filename="../qml/pages/LockScreenPage.qml" line="66"/>
@@ -269,77 +269,77 @@
     <message id="ph-recommended-page-header">
         <location filename="../qml/pages/RecommendedPage.qml" line="134"/>
         <source>Recommended</source>
-        <translation>Raccomandati</translation>
+        <translation>Suositellut</translation>
     </message>
     <message id="ph-recommended-page-pornstars-section-header">
         <location filename="../qml/pages/RecommendedPage.qml" line="140"/>
         <source>Pornstars</source>
-        <translation>Pornostar</translation>
+        <translation>Pornotähdet</translation>
     </message>
     <message id="ph-recommended-page-categories-section-header">
         <location filename="../qml/pages/RecommendedPage.qml" line="203"/>
         <source>Categories</source>
-        <translation>Categorie</translation>
+        <translation>Kategoriat</translation>
     </message>
     <message id="ph-start-page-videos-hottest">
         <location filename="../qml/pages/StartPage.qml" line="47"/>
         <source>Hottest</source>
-        <translation>Più caldi</translation>
+        <translation>Kuumimmat</translation>
     </message>
     <message id="ph-start-page-videos-most-viewed">
         <location filename="../qml/pages/StartPage.qml" line="54"/>
         <source>Most Viewed</source>
-        <translation>Più visti</translation>
+        <translation>Eniten katsellut</translation>
     </message>
     <message id="ph-start-page-videos-top-ratedmost-viewed">
         <location filename="../qml/pages/StartPage.qml" line="61"/>
         <source>Top Rated</source>
-        <translation>Valuitazione positiva</translation>
+        <translation>Parhaiten arvostellut</translation>
     </message>
     <message id="ph-start-page-videos-popular-homemade">
         <location filename="../qml/pages/StartPage.qml" line="68"/>
         <source>Popular Homemade</source>
-        <translation>Fatti in casa popolari</translation>
+        <translation>Suositut kotivideot</translation>
     </message>
     <message id="ph-start-page-categories-popular">
         <location filename="../qml/pages/StartPage.qml" line="78"/>
         <source>Popular</source>
-        <translation>Popolari</translation>
+        <translation>Suosituimmat</translation>
     </message>
     <message id="ph-start-page-categories-alphabetical">
         <location filename="../qml/pages/StartPage.qml" line="85"/>
         <source>Alphabetical</source>
-        <translation>Alfabetico</translation>
+        <translation>Aakkosjärjestys</translation>
     </message>
     <message id="ph-start-page-categories-no-videos">
         <location filename="../qml/pages/StartPage.qml" line="92"/>
         <source>Number of Videos</source>
-        <translation>Numero di video</translation>
+        <translation>Videoiden määrät</translation>
     </message>
     <message id="ph-start-page-pornstars-most-popular">
         <location filename="../qml/pages/StartPage.qml" line="102"/>
         <source>Most Popular</source>
-        <translation>Più popolari</translation>
+        <translation>Suosituimmat</translation>
     </message>
     <message id="ph-start-page-pornstars-top-trending">
         <location filename="../qml/pages/StartPage.qml" line="109"/>
         <source>Top Trending</source>
-        <translation>Di tendenza</translation>
+        <translation>Nousijat</translation>
     </message>
     <message id="ph-start-page-pornstars-most-viewed">
         <location filename="../qml/pages/StartPage.qml" line="116"/>
         <source>Most Viewed</source>
-        <translation>Più visti</translation>
+        <translation>Eniten katsellut</translation>
     </message>
     <message id="ph-start-page-pornstars-most-subscribed">
         <location filename="../qml/pages/StartPage.qml" line="123"/>
         <source>Most Subscribed</source>
-        <translation>Più sottoscritti</translation>
+        <translation>Eniten tilatut</translation>
     </message>
     <message id="ph-start-page-pornstars-no-videos">
         <location filename="../qml/pages/StartPage.qml" line="137"/>
         <source>Number of Videos</source>
-        <translation>Numero di video</translation>
+        <translation>Videoiden määrät</translation>
     </message>
     <message id="ph-start-page-header">
         <location filename="../qml/pages/StartPage.qml" line="197"/>
@@ -349,129 +349,129 @@
     <message id="ph-start-page-videos-recommended">
         <location filename="../qml/pages/StartPage.qml" line="202"/>
         <source>Recommended</source>
-        <translation>Raccomandati</translation>
+        <translation>Suositellut</translation>
     </message>
     <message id="ph-start-page-videos-section-title">
         <location filename="../qml/pages/StartPage.qml" line="215"/>
         <source>Videos</source>
-        <translation>Video</translation>
+        <translation>Videot</translation>
     </message>
     <message id="ph-start-page-search-placeholder">
         <location filename="../qml/pages/StartPage.qml" line="239"/>
         <location filename="../qml/pages/StartPage.qml" line="305"/>
         <source>Search</source>
-        <translation>Cerca</translation>
+        <translation>Hae</translation>
     </message>
     <message id="ph-start-page-categories-section-title">
         <location filename="../qml/pages/StartPage.qml" line="256"/>
         <source>Categories</source>
-        <translation>Categorie</translation>
+        <translation>Kategoriat</translation>
     </message>
     <message id="ph-start-page-pornstars-section-title">
         <location filename="../qml/pages/StartPage.qml" line="281"/>
         <source>Pornstars</source>
-        <translation>Pornostar</translation>
+        <translation>Pornotähdet</translation>
     </message>
     <message id="ph-start-page-my-section-title">
         <location filename="../qml/pages/StartPage.qml" line="322"/>
         <source>My</source>
-        <translation>I miei</translation>
+        <translation>Omat</translation>
     </message>
     <message id="ph-start-page-user-videos-favorites">
         <location filename="../qml/pages/StartPage.qml" line="357"/>
         <source>Favorites</source>
-        <translation>Preferiti</translation>
+        <translation>Suosikit</translation>
     </message>
     <message id="ph-format-combobox-format-label">
         <location filename="../qml/FormatComboBox.qml" line="35"/>
         <source>Format</source>
-        <translation>Formato</translation>
+        <translation>Laatuasetukset</translation>
     </message>
     <message id="ph-format-combobox-format-best">
         <location filename="../qml/FormatComboBox.qml" line="41"/>
         <source>best quality (largest)</source>
-        <translation>qualità migliore (più grandi)</translation>
+        <translation>Paras laatu (suurin koko)</translation>
     </message>
     <message id="ph-format-combobox-format-worst">
         <location filename="../qml/FormatComboBox.qml" line="45"/>
         <source>worst quality (smallest)</source>
-        <translation>qualità peggiore (più piccoli)</translation>
+        <translation>Huonoin laatu (pienin koko)</translation>
     </message>
     <message id="ph-top-menu-about">
         <location filename="../qml/TopMenu.qml" line="34"/>
         <source>About %1</source>
-        <translation>Info su %1</translation>
+        <translation>Tietoja</translation>
     </message>
     <message id="ph-top-menu-settings">
         <location filename="../qml/TopMenu.qml" line="40"/>
         <source>Settings</source>
-        <translation>Impostazioni</translation>
+        <translation>Asetukset</translation>
     </message>
     <message id="ph-top-menu-reload">
         <location filename="../qml/TopMenu.qml" line="46"/>
         <source>Reload</source>
-        <translation>Ricarica</translation>
+        <translation>Päivitä</translation>
     </message>
     <message id="ph-top-menu-logout">
         <location filename="../qml/TopMenu.qml" line="59"/>
         <source>Logout</source>
-        <translation>Esci</translation>
+        <translation>Kirjaudu ulos</translation>
     </message>
     <message id="ph-top-menu-login">
         <location filename="../qml/TopMenu.qml" line="66"/>
         <source>Login</source>
-        <translation>Accedi</translation>
+        <translation>Kirjaudu sisään</translation>
     </message>
     <message id="ph-model-videos-page-title">
         <location filename="../qml/pages/VideoPlayerPage.qml" line="575"/>
         <location filename="../qml/pages/VideoPlayerPage.qml" line="593"/>
         <source>%1&apos;s Videos</source>
-        <translation>Video di %1</translation>
+        <translation>Esiintyjän %1 videot</translation>
     </message>
     <message id="ph-translations-page-header">
         <location filename="../qml/pages/TranslationsPage.qml" line="46"/>
         <source>Translations</source>
-        <translation>Traduzioni</translation>
+        <translation>Käännökset</translation>
     </message>
     <message id="ph-translations-page-english-label">
         <location filename="../qml/pages/TranslationsPage.qml" line="60"/>
         <source>English</source>
-        <translation>Inglese</translation>
+        <translation>englanti</translation>
     </message>
     <message id="ph-translations-page-simplified-chinese-label">
         <location filename="../qml/pages/TranslationsPage.qml" line="66"/>
         <source>Simplified Chinese</source>
-        <translation>Cinese semplificato</translation>
+        <translation>yksinkertaistettu kiina</translation>
     </message>
     <message id="ph-translations-page-italian-label">
         <location filename="../qml/pages/TranslationsPage.qml" line="72"/>
         <source>Italian</source>
-        <translation>Italiano</translation>
+        <translation>italia</translation>
     </message>
     <message id="ph-translations-page-finnish-label">
         <location filename="../qml/pages/TranslationsPage.qml" line="78"/>
         <source>Finnish</source>
-        <translation type="unfinished">Finlandese</translation>
+        <translation>suomi</translation>
     </message>
     <message id="ph-login-succes-message">
         <location filename="../qml/harbour-phillis.qml" line="83"/>
         <source>Login success</source>
-        <translation>Accesso effettuato</translation>
+        <translation>Kirjautuminen onnistui</translation>
     </message>
     <message id="ph-error-message-initial-request-failed">
         <location filename="../qml/harbour-phillis.qml" line="120"/>
         <source>Initial loading of website failed</source>
-        <translation>Caricamento del sito fallito</translation>
+        <translation>Verkkosisällön laataminen epäonnistui</translation>
     </message>
     <message id="ph-setting-lock-screen-text">
         <location filename="../qml/harbour-phillis.qml" line="243"/>
         <source>Please enter your online trading PIN</source>
-        <translation>Inserisci il tuo PIN online</translation>
+        <translation>Ole hyvä ja syötä online-kaupankäynnin PIN-koodisi</translation>
     </message>
     <message id="ph-error-request-failed-summary">
         <location filename="../qml/harbour-phillis.qml" line="357"/>
         <source>Request failed</source>
-        <translation>Richiesta fallita</translation>
+        <translation>Pyyntö epäonnistui</translation>
     </message>
 </context>
 </TS>

--- a/translations/harbour-phillis-it.ts
+++ b/translations/harbour-phillis-it.ts
@@ -4,371 +4,381 @@
 <context>
     <name></name>
     <message id="ph-settings-page-header">
-        <location filename="../qml/pages/SettingsPage.qml" line="47"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="52"/>
         <source>Settings</source>
         <translation>Impostazioni</translation>
     </message>
     <message id="ph-settings-page-network-header">
-        <location filename="../qml/pages/SettingsPage.qml" line="52"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="57"/>
         <source>Network</source>
         <translation>Rete</translation>
     </message>
     <message id="ph-settings-page-network-connection-type">
-        <location filename="../qml/pages/SettingsPage.qml" line="59"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="64"/>
         <source>Network connection type</source>
         <translation>Tipo connessione di rete</translation>
     </message>
     <message id="ph-settings-page-network-connection-autodetect">
-        <location filename="../qml/pages/SettingsPage.qml" line="63"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="68"/>
         <source>Autodetect</source>
         <translation>Automatico</translation>
     </message>
     <message id="ph-settings-page-network-connection-broadband">
-        <location filename="../qml/pages/SettingsPage.qml" line="67"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="72"/>
         <source>Broadband</source>
         <translation>Broadband</translation>
     </message>
     <message id="ph-settings-page-network-connection-mobile">
-        <location filename="../qml/pages/SettingsPage.qml" line="71"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="76"/>
         <source>Mobile</source>
         <translation>Mobile</translation>
     </message>
     <message id="ph-format-label">
-        <location filename="../qml/pages/SettingsPage.qml" line="85"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="90"/>
         <source>Format</source>
         <translation>Formato</translation>
     </message>
     <message id="ph-settings-page-network-broadband-label">
-        <location filename="../qml/pages/SettingsPage.qml" line="90"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="95"/>
         <source>Broadband</source>
         <translation>Broadband</translation>
     </message>
     <message id="ph-settings-page-network-mobile-label">
-        <location filename="../qml/pages/SettingsPage.qml" line="104"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="109"/>
         <source>Mobile</source>
         <translation>Mobile</translation>
     </message>
     <message id="ph-settings-page-content-preferences-section-header">
-        <location filename="../qml/pages/SettingsPage.qml" line="118"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="123"/>
         <source>Content Preferences</source>
         <translation>Preferenze contenuto</translation>
     </message>
     <message id="ph-settings-page-content-preferences-gay-only-switch-text">
-        <location filename="../qml/pages/SettingsPage.qml" line="127"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="132"/>
         <source>Gay Only</source>
         <translation>Solo gay</translation>
     </message>
     <message id="ph-settings-page-content-preferences-gay-only-switch-description">
-        <location filename="../qml/pages/SettingsPage.qml" line="129"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="134"/>
         <source>Only show gay categories and videos</source>
         <translation>Mostra solo categorie e video gay</translation>
     </message>
     <message id="ph-settings-page-playback-section-header">
-        <location filename="../qml/pages/SettingsPage.qml" line="145"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="150"/>
         <source>Playback</source>
         <translation>Riproduzione</translation>
     </message>
     <message id="ph-settings-page-playback-pause-on-device-lock-switch">
-        <location filename="../qml/pages/SettingsPage.qml" line="150"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="155"/>
         <source>Pause playback on device lock</source>
         <translation>Metti in pausa al blocco del dispositivo</translation>
     </message>
     <message id="ph-settings-page-playback-pause-if-cover-page-switch">
-        <location filename="../qml/pages/SettingsPage.qml" line="160"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="165"/>
         <source>Pause playback when the cover page is shown</source>
         <translation>Metti in pausa quando minimizzato nella cover</translation>
     </message>
     <message id="ph-settings-page-display">
-        <location filename="../qml/pages/SettingsPage.qml" line="170"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="175"/>
         <source>Display</source>
         <translation>Mostra</translation>
     </message>
+    <message id="ph-settings-page-display-videos-per-grid-row">
+        <location filename="../qml/pages/SettingsPage.qml" line="182"/>
+        <source>Videos per row</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="ph-settings-page-display-categories-per-grid-row">
-        <location filename="../qml/pages/SettingsPage.qml" line="177"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="207"/>
         <source>Categories per row</source>
         <translation>Categorie per riga</translation>
     </message>
     <message id="ph-settings-page-display-pornstars-per-grid-row">
-        <location filename="../qml/pages/SettingsPage.qml" line="202"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="232"/>
         <source>Pornstars per row</source>
         <translation>Pornostar per riga</translation>
     </message>
+    <message id="ph-settings-page-display-extra-landscape-column">
+        <location filename="../qml/pages/SettingsPage.qml" line="255"/>
+        <source>Add one extra column in landscape orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="ph-settings-page-access">
-        <location filename="../qml/pages/SettingsPage.qml" line="225"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="265"/>
         <source>Access</source>
         <translation>Accesso</translation>
     </message>
     <message id="ph-settings-page-access-restrict-text">
-        <location filename="../qml/pages/SettingsPage.qml" line="230"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="270"/>
         <source>Require a PIN to access the app</source>
         <translation>Richiedi un PIN per accedere all&apos;app</translation>
     </message>
     <message id="ph-settings-page-access-restrict-description">
-        <location filename="../qml/pages/SettingsPage.qml" line="232"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="272"/>
         <source>Protect against accidently accessing the application. The PIN will be stored as plain text in the application configuration directory. Should you forget your PIN simply delete the file to restore access to the application.</source>
         <translation>Proteggi contro l&apos;accesso accidentale all&apos;app. Il PIN sarà salvato come file di testo nella cartella di configurazione dell&apos;app, per cui nel caso dovessi dimenticarlo ti basterà cancellare quel file per ripristinare l&apos;accesso all&apos;app.</translation>
     </message>
     <message id="ph-settings-page-access-require-pin-label">
-        <location filename="../qml/pages/SettingsPage.qml" line="248"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="288"/>
         <source>PIN</source>
         <translation>PIN</translation>
     </message>
     <message id="ph-settings-page-access-require-pin-placeholder">
-        <location filename="../qml/pages/SettingsPage.qml" line="250"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="290"/>
         <source>Enter four or more digits</source>
         <translation>Inserisci almeno quattro cifre</translation>
     </message>
     <message id="ph-settings-page-access-lock-screen-text">
-        <location filename="../qml/pages/SettingsPage.qml" line="265"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="305"/>
         <source>Lock screen text</source>
         <translation>Testo blocco schermo</translation>
     </message>
     <message id="ph-settings-page-account">
-        <location filename="../qml/pages/SettingsPage.qml" line="278"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="318"/>
         <source>Account</source>
         <translation>Account</translation>
     </message>
     <message id="ph-settings-page-account-username">
-        <location filename="../qml/pages/SettingsPage.qml" line="283"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="323"/>
         <source>Username</source>
         <translation>Nome utente</translation>
     </message>
     <message id="ph-settings-page-account-auto-login">
-        <location filename="../qml/pages/SettingsPage.qml" line="309"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="349"/>
         <source>Login on application start</source>
         <translation>Accedi all&apos;avvio dell&apos;app</translation>
     </message>
     <message id="ph-about-page-header">
-        <location filename="../qml/pages/AboutPage.qml" line="42"/>
+        <location filename="../qml/pages/AboutPage.qml" line="47"/>
         <source>About %1</source>
         <translation>Info su %1</translation>
     </message>
     <message id="ph-about-page-version-text">
-        <location filename="../qml/pages/AboutPage.qml" line="90"/>
+        <location filename="../qml/pages/AboutPage.qml" line="95"/>
         <source>%1 %2</source>
         <translation>%1 %2</translation>
     </message>
     <message id="ph-about-page-description-header">
-        <location filename="../qml/pages/AboutPage.qml" line="107"/>
+        <location filename="../qml/pages/AboutPage.qml" line="112"/>
         <source>Description</source>
         <translation>Descrizione</translation>
     </message>
     <message id="ph-about-page-description-text">
-        <location filename="../qml/pages/AboutPage.qml" line="114"/>
+        <location filename="../qml/pages/AboutPage.qml" line="119"/>
         <source>%1 is an unofficial Sailfish OS client for the adult content website &lt;a href=&apos;https://www.pornhub.com/&apos;&gt;Pornhub&lt;/a&gt;.</source>
         <translation>%1 è un client non ufficiale Sailfish OS del sito web per adulti &lt;a href=&apos;https://www.pornhub.com/&apos;&gt;Pornhub&lt;/a&gt;.</translation>
     </message>
     <message id="about-page-disclaimer-header">
-        <location filename="../qml/pages/AboutPage.qml" line="123"/>
+        <location filename="../qml/pages/AboutPage.qml" line="128"/>
         <source>Disclaimer</source>
         <translation>Esclusione della responsabilità</translation>
     </message>
     <message id="ph-about-page-disclaimer-text">
-        <location filename="../qml/pages/AboutPage.qml" line="130"/>
+        <location filename="../qml/pages/AboutPage.qml" line="135"/>
         <source>The content provided through %1 is the property and sole responsibility of &lt;a href=&apos;https://www.pornhub.com/&apos;&gt;Pornhub&lt;/a&gt;.</source>
         <translation>Il contenuto fruito attraverso %1 è proprietà e responsabilità di &lt;a href=&apos;https://www.pornhub.com/&apos;&gt;Pornhub&lt;/a&gt;.</translation>
     </message>
     <message id="about-page-credits-licenses-sources-header">
-        <location filename="../qml/pages/AboutPage.qml" line="139"/>
+        <location filename="../qml/pages/AboutPage.qml" line="144"/>
         <source>Credits, Licenses, and Sources</source>
         <translation>Crediti, licenze e sorgenti</translation>
     </message>
     <message id="ph-about-page-credits-licenses-sources-text">
-        <location filename="../qml/pages/AboutPage.qml" line="146"/>
+        <location filename="../qml/pages/AboutPage.qml" line="151"/>
         <source>Copyright © 2019 grumpycat&lt;br/&gt;&lt;br/&gt;This application is available under the MIT licence on &lt;a href=&apos;https://github.com/grumpycat3051/harbour-phillis/&apos;&gt;Github&lt;/a&gt;. %1 uses icons made by Smashicons from &lt;a href=&apos;https://www.flaticon.com/&apos;&gt;flaticon&lt;/a&gt;.</source>
         <oldsource>Copyright © 2019 grumpycat&lt;br/&gt;&lt;br/&gt;This application is available under the MIT licence on &lt;a href=&apos;https://github.com/grumpycat3051/harbour-phillis/&apos;&gt;Github&lt;/a&gt;.&lt;br/&gt;%1 uses icons made by Smashicons from &lt;a href=&apos;https://www.flaticon.com/&apos;&gt;flaticon&lt;/a&gt;.</oldsource>
         <translation>Copyright © 2019 grumpycat&lt;br/&gt;&lt;br/&gt;Quest&apos;app è rilasciata sotto licenza MIT su &lt;a href=&apos;https://github.com/grumpycat3051/harbour-phillis/&apos;&gt;Github&lt;/a&gt;. %1 utilizza le icone di Smashicons da &lt;a href=&apos;https://www.flaticon.com/&apos;&gt;flaticon&lt;/a&gt;.</translation>
     </message>
     <message id="ph-about-privacy-header">
-        <location filename="../qml/pages/AboutPage.qml" line="168"/>
+        <location filename="../qml/pages/AboutPage.qml" line="173"/>
         <source>Privacy</source>
         <translation>Privacy</translation>
     </message>
     <message id="ph-about-page-privacy-text">
-        <location filename="../qml/pages/AboutPage.qml" line="175"/>
+        <location filename="../qml/pages/AboutPage.qml" line="180"/>
         <source>This application does not collect or save any personal data aside from possibly those credentials required to sign into &lt;a href=&apos;https://www.pornhub.com/&apos;&gt;Pornhub&lt;/a&gt;.</source>
         <translation>Quest&apos;app non salva né raccoglie nessun dato personale. Se effettui l&apos;accesso, l&apos;app salverà le credenziali di &lt;a href=&apos;https://www.pornhub.com/&apos;&gt;Pornhub&lt;/a&gt;.</translation>
     </message>
     <message id="about-page-translations-button">
-        <location filename="../qml/pages/AboutPage.qml" line="161"/>
+        <location filename="../qml/pages/AboutPage.qml" line="166"/>
         <source>Translations</source>
         <translation>Traduzioni</translation>
     </message>
     <message id="ph-categories-page-filter-placeholder">
-        <location filename="../qml/pages/CategoriesPage.qml" line="115"/>
+        <location filename="../qml/pages/CategoriesPage.qml" line="117"/>
         <source>Filter</source>
         <translation>Filtri</translation>
     </message>
     <message id="ph-categories-page-view-placeholder-text-loading">
-        <location filename="../qml/pages/CategoriesPage.qml" line="203"/>
+        <location filename="../qml/pages/CategoriesPage.qml" line="205"/>
         <source>Categories are being loaded</source>
         <translation>Caricamento categorie</translation>
     </message>
     <message id="ph-push-up-menu-load-more">
-        <location filename="../qml/pages/PornstarsPage.qml" line="114"/>
-        <location filename="../qml/pages/VideosPage.qml" line="93"/>
+        <location filename="../qml/pages/PornstarsPage.qml" line="116"/>
+        <location filename="../qml/pages/VideosPage.qml" line="97"/>
         <source>Load more</source>
         <translation>Carica altro</translation>
     </message>
     <message id="ph-pornstars-page-view-placeholder-text-loading">
-        <location filename="../qml/pages/PornstarsPage.qml" line="172"/>
+        <location filename="../qml/pages/PornstarsPage.qml" line="174"/>
         <source>Pornstars are being loaded</source>
         <translation>Caricamento pornostar</translation>
     </message>
     <message id="ph-view-placeholder-text-no-results">
-        <location filename="../qml/pages/PornstarsPage.qml" line="177"/>
-        <location filename="../qml/pages/VideosPage.qml" line="200"/>
+        <location filename="../qml/pages/PornstarsPage.qml" line="179"/>
+        <location filename="../qml/pages/VideosPage.qml" line="207"/>
         <source>Search yielded no results</source>
         <translation>La ricerca non ha fornito risultati</translation>
     </message>
     <message id="ph-videos-page-context-menu-copy-url-to-clipboard">
-        <location filename="../qml/pages/VideosPage.qml" line="123"/>
+        <location filename="../qml/pages/VideosPage.qml" line="130"/>
         <source>Copy URL to clipboard</source>
         <translation>Copia URL negli appunti</translation>
     </message>
     <message id="ph-videos-page-view-placeholder-text-loading">
-        <location filename="../qml/pages/VideosPage.qml" line="195"/>
+        <location filename="../qml/pages/VideosPage.qml" line="202"/>
         <source>Videos are being loaded</source>
         <translation>Caricamento video</translation>
     </message>
     <message id="ph-disclaimer-page-title">
-        <location filename="../qml/pages/AdultContentDisclaimerPage.qml" line="57"/>
+        <location filename="../qml/pages/AdultContentDisclaimerPage.qml" line="60"/>
         <source>Adult Content Disclaimer</source>
         <translation>Clausola di esclusione della responsabilità</translation>
     </message>
     <message id="ph-disclaimer-page-text1">
-        <location filename="../qml/pages/AdultContentDisclaimerPage.qml" line="70"/>
+        <location filename="../qml/pages/AdultContentDisclaimerPage.qml" line="73"/>
         <source>The content provided through this app is designed for ADULTS only and may include pictures and materials that some viewers may find offensive. If you are under the age of 18, if such material offends you or if it is illegal to view such material in your community please exit the site. The following terms and conditions apply to this site. Use of the site will constitute your agreement to the following terms and conditions:</source>
         <translation>Il contenuto fruito attraverso quest&apos;app è destinato soltanto ad ADULTI e potrebbe includere immagini e materiale che alcuni utenti potrebbero trovare offensivo. Se sei minorenne, se questo materiale ti offende o se ti trovi in paesi nei quali guardare questo materiale è illegale, esci da questo sito. L&apos;utilizzo del sito costituisce l&apos;accettazione dei seguenti termini e condizioni:</translation>
     </message>
     <message id="ph-disclaimer-page-text2">
-        <location filename="../qml/pages/AdultContentDisclaimerPage.qml" line="83"/>
+        <location filename="../qml/pages/AdultContentDisclaimerPage.qml" line="86"/>
         <source>1.) I am 18 years of age or older&lt;br/&gt;2.) I accept all responsibility for my own actions; and&lt;br/&gt;3.) I agree that I am legally bound to these Terms and Conditions</source>
         <translation>1) Sono maggiorenne&lt;br/&gt;2) Accetto la responsabilità delle mie azioni&lt;br/&gt;3) Accetto che questi termini e condizioni abbiano valore legale</translation>
     </message>
     <message id="ph-disclaimer-page-accept-button">
-        <location filename="../qml/pages/AdultContentDisclaimerPage.qml" line="98"/>
+        <location filename="../qml/pages/AdultContentDisclaimerPage.qml" line="101"/>
         <source>Accept</source>
         <translation>Accetto</translation>
     </message>
     <message id="ph-lock-screen-page-pin-placeholder">
-        <location filename="../qml/pages/LockScreenPage.qml" line="65"/>
+        <location filename="../qml/pages/LockScreenPage.qml" line="66"/>
         <source>PIN</source>
         <translation>PIN</translation>
     </message>
     <message id="ph-recommended-page-header">
-        <location filename="../qml/pages/RecommendedPage.qml" line="133"/>
+        <location filename="../qml/pages/RecommendedPage.qml" line="134"/>
         <source>Recommended</source>
         <translation>Raccomandati</translation>
     </message>
     <message id="ph-recommended-page-pornstars-section-header">
-        <location filename="../qml/pages/RecommendedPage.qml" line="139"/>
+        <location filename="../qml/pages/RecommendedPage.qml" line="140"/>
         <source>Pornstars</source>
         <translation>Pornostar</translation>
     </message>
     <message id="ph-recommended-page-categories-section-header">
-        <location filename="../qml/pages/RecommendedPage.qml" line="202"/>
+        <location filename="../qml/pages/RecommendedPage.qml" line="203"/>
         <source>Categories</source>
         <translation>Categorie</translation>
     </message>
     <message id="ph-start-page-videos-hottest">
-        <location filename="../qml/pages/StartPage.qml" line="46"/>
+        <location filename="../qml/pages/StartPage.qml" line="47"/>
         <source>Hottest</source>
         <translation>Più caldi</translation>
     </message>
     <message id="ph-start-page-videos-most-viewed">
-        <location filename="../qml/pages/StartPage.qml" line="53"/>
+        <location filename="../qml/pages/StartPage.qml" line="54"/>
         <source>Most Viewed</source>
         <translation>Più visti</translation>
     </message>
     <message id="ph-start-page-videos-top-ratedmost-viewed">
-        <location filename="../qml/pages/StartPage.qml" line="60"/>
+        <location filename="../qml/pages/StartPage.qml" line="61"/>
         <source>Top Rated</source>
         <translation>Valuitazione positiva</translation>
     </message>
     <message id="ph-start-page-videos-popular-homemade">
-        <location filename="../qml/pages/StartPage.qml" line="67"/>
+        <location filename="../qml/pages/StartPage.qml" line="68"/>
         <source>Popular Homemade</source>
         <translation>Fatti in casa popolari</translation>
     </message>
     <message id="ph-start-page-categories-popular">
-        <location filename="../qml/pages/StartPage.qml" line="77"/>
+        <location filename="../qml/pages/StartPage.qml" line="78"/>
         <source>Popular</source>
         <translation>Popolari</translation>
     </message>
     <message id="ph-start-page-categories-alphabetical">
-        <location filename="../qml/pages/StartPage.qml" line="84"/>
+        <location filename="../qml/pages/StartPage.qml" line="85"/>
         <source>Alphabetical</source>
         <translation>Alfabetico</translation>
     </message>
     <message id="ph-start-page-categories-no-videos">
-        <location filename="../qml/pages/StartPage.qml" line="91"/>
+        <location filename="../qml/pages/StartPage.qml" line="92"/>
         <source>Number of Videos</source>
         <translation>Numero di video</translation>
     </message>
     <message id="ph-start-page-pornstars-most-popular">
-        <location filename="../qml/pages/StartPage.qml" line="101"/>
+        <location filename="../qml/pages/StartPage.qml" line="102"/>
         <source>Most Popular</source>
         <translation>Più popolari</translation>
     </message>
     <message id="ph-start-page-pornstars-top-trending">
-        <location filename="../qml/pages/StartPage.qml" line="108"/>
+        <location filename="../qml/pages/StartPage.qml" line="109"/>
         <source>Top Trending</source>
         <translation>Di tendenza</translation>
     </message>
     <message id="ph-start-page-pornstars-most-viewed">
-        <location filename="../qml/pages/StartPage.qml" line="115"/>
+        <location filename="../qml/pages/StartPage.qml" line="116"/>
         <source>Most Viewed</source>
         <translation>Più visti</translation>
     </message>
     <message id="ph-start-page-pornstars-most-subscribed">
-        <location filename="../qml/pages/StartPage.qml" line="122"/>
+        <location filename="../qml/pages/StartPage.qml" line="123"/>
         <source>Most Subscribed</source>
         <translation>Più sottoscritti</translation>
     </message>
     <message id="ph-start-page-pornstars-no-videos">
-        <location filename="../qml/pages/StartPage.qml" line="136"/>
+        <location filename="../qml/pages/StartPage.qml" line="137"/>
         <source>Number of Videos</source>
         <translation>Numero di video</translation>
     </message>
     <message id="ph-start-page-header">
-        <location filename="../qml/pages/StartPage.qml" line="192"/>
+        <location filename="../qml/pages/StartPage.qml" line="197"/>
         <source>Pornhub</source>
         <translation>Pornhub</translation>
     </message>
     <message id="ph-start-page-videos-recommended">
-        <location filename="../qml/pages/StartPage.qml" line="197"/>
+        <location filename="../qml/pages/StartPage.qml" line="202"/>
         <source>Recommended</source>
         <translation>Raccomandati</translation>
     </message>
     <message id="ph-start-page-videos-section-title">
-        <location filename="../qml/pages/StartPage.qml" line="210"/>
+        <location filename="../qml/pages/StartPage.qml" line="215"/>
         <source>Videos</source>
         <translation>Video</translation>
     </message>
     <message id="ph-start-page-search-placeholder">
-        <location filename="../qml/pages/StartPage.qml" line="234"/>
-        <location filename="../qml/pages/StartPage.qml" line="300"/>
+        <location filename="../qml/pages/StartPage.qml" line="239"/>
+        <location filename="../qml/pages/StartPage.qml" line="305"/>
         <source>Search</source>
         <translation>Cerca</translation>
     </message>
     <message id="ph-start-page-categories-section-title">
-        <location filename="../qml/pages/StartPage.qml" line="251"/>
+        <location filename="../qml/pages/StartPage.qml" line="256"/>
         <source>Categories</source>
         <translation>Categorie</translation>
     </message>
     <message id="ph-start-page-pornstars-section-title">
-        <location filename="../qml/pages/StartPage.qml" line="276"/>
+        <location filename="../qml/pages/StartPage.qml" line="281"/>
         <source>Pornstars</source>
         <translation>Pornostar</translation>
     </message>
     <message id="ph-start-page-my-section-title">
-        <location filename="../qml/pages/StartPage.qml" line="317"/>
+        <location filename="../qml/pages/StartPage.qml" line="322"/>
         <source>My</source>
         <translation>I miei</translation>
     </message>
     <message id="ph-start-page-user-videos-favorites">
-        <location filename="../qml/pages/StartPage.qml" line="352"/>
+        <location filename="../qml/pages/StartPage.qml" line="357"/>
         <source>Favorites</source>
         <translation>Preferiti</translation>
     </message>
@@ -419,22 +429,22 @@
         <translation>Video di %1</translation>
     </message>
     <message id="ph-translations-page-header">
-        <location filename="../qml/pages/TranslationsPage.qml" line="41"/>
+        <location filename="../qml/pages/TranslationsPage.qml" line="46"/>
         <source>Translations</source>
         <translation>Traduzioni</translation>
     </message>
     <message id="ph-translations-page-english-label">
-        <location filename="../qml/pages/TranslationsPage.qml" line="55"/>
+        <location filename="../qml/pages/TranslationsPage.qml" line="60"/>
         <source>English</source>
         <translation>Inglese</translation>
     </message>
     <message id="ph-translations-page-simplified-chinese-label">
-        <location filename="../qml/pages/TranslationsPage.qml" line="61"/>
+        <location filename="../qml/pages/TranslationsPage.qml" line="66"/>
         <source>Simplified Chinese</source>
         <translation>Cinese semplificato</translation>
     </message>
     <message id="ph-translations-page-italian-label">
-        <location filename="../qml/pages/TranslationsPage.qml" line="67"/>
+        <location filename="../qml/pages/TranslationsPage.qml" line="72"/>
         <source>Italian</source>
         <translation>Italiano</translation>
     </message>
@@ -444,17 +454,17 @@
         <translation>Accesso effettuato</translation>
     </message>
     <message id="ph-error-message-initial-request-failed">
-        <location filename="../qml/harbour-phillis.qml" line="118"/>
+        <location filename="../qml/harbour-phillis.qml" line="120"/>
         <source>Initial loading of website failed</source>
         <translation>Caricamento del sito fallito</translation>
     </message>
     <message id="ph-setting-lock-screen-text">
-        <location filename="../qml/harbour-phillis.qml" line="229"/>
+        <location filename="../qml/harbour-phillis.qml" line="243"/>
         <source>Please enter your online trading PIN</source>
         <translation>Inserisci il tuo PIN online</translation>
     </message>
     <message id="ph-error-request-failed-summary">
-        <location filename="../qml/harbour-phillis.qml" line="345"/>
+        <location filename="../qml/harbour-phillis.qml" line="357"/>
         <source>Request failed</source>
         <translation>Richiesta fallita</translation>
     </message>

--- a/translations/harbour-phillis-zh_CN.ts
+++ b/translations/harbour-phillis-zh_CN.ts
@@ -4,371 +4,381 @@
 <context>
     <name></name>
     <message id="ph-settings-page-header">
-        <location filename="../qml/pages/SettingsPage.qml" line="47"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="52"/>
         <source>Settings</source>
         <translation>设置</translation>
     </message>
     <message id="ph-settings-page-network-header">
-        <location filename="../qml/pages/SettingsPage.qml" line="52"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="57"/>
         <source>Network</source>
         <translation>网络</translation>
     </message>
     <message id="ph-settings-page-network-connection-type">
-        <location filename="../qml/pages/SettingsPage.qml" line="59"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="64"/>
         <source>Network connection type</source>
         <translation>网络连接类型</translation>
     </message>
     <message id="ph-settings-page-network-connection-autodetect">
-        <location filename="../qml/pages/SettingsPage.qml" line="63"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="68"/>
         <source>Autodetect</source>
         <translation>自动检测</translation>
     </message>
     <message id="ph-settings-page-network-connection-broadband">
-        <location filename="../qml/pages/SettingsPage.qml" line="67"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="72"/>
         <source>Broadband</source>
         <translation>宽带</translation>
     </message>
     <message id="ph-settings-page-network-connection-mobile">
-        <location filename="../qml/pages/SettingsPage.qml" line="71"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="76"/>
         <source>Mobile</source>
         <translation>移动数据</translation>
     </message>
     <message id="ph-format-label">
-        <location filename="../qml/pages/SettingsPage.qml" line="85"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="90"/>
         <source>Format</source>
         <translation>格式</translation>
     </message>
     <message id="ph-settings-page-network-broadband-label">
-        <location filename="../qml/pages/SettingsPage.qml" line="90"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="95"/>
         <source>Broadband</source>
         <translation>宽带</translation>
     </message>
     <message id="ph-settings-page-network-mobile-label">
-        <location filename="../qml/pages/SettingsPage.qml" line="104"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="109"/>
         <source>Mobile</source>
         <translation>移动数据</translation>
     </message>
     <message id="ph-settings-page-content-preferences-section-header">
-        <location filename="../qml/pages/SettingsPage.qml" line="118"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="123"/>
         <source>Content Preferences</source>
         <translation>内容偏好</translation>
     </message>
     <message id="ph-settings-page-content-preferences-gay-only-switch-text">
-        <location filename="../qml/pages/SettingsPage.qml" line="127"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="132"/>
         <source>Gay Only</source>
         <translation>仅显示 Gay 内容</translation>
     </message>
     <message id="ph-settings-page-content-preferences-gay-only-switch-description">
-        <location filename="../qml/pages/SettingsPage.qml" line="129"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="134"/>
         <source>Only show gay categories and videos</source>
         <translation>仅显示 Gay 分类及视频</translation>
     </message>
     <message id="ph-settings-page-playback-section-header">
-        <location filename="../qml/pages/SettingsPage.qml" line="145"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="150"/>
         <source>Playback</source>
         <translation>播放</translation>
     </message>
     <message id="ph-settings-page-playback-pause-on-device-lock-switch">
-        <location filename="../qml/pages/SettingsPage.qml" line="150"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="155"/>
         <source>Pause playback on device lock</source>
         <translation>设备锁定时停止播放</translation>
     </message>
     <message id="ph-settings-page-playback-pause-if-cover-page-switch">
-        <location filename="../qml/pages/SettingsPage.qml" line="160"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="165"/>
         <source>Pause playback when the cover page is shown</source>
         <translation>显示封面页面时停止播放</translation>
     </message>
     <message id="ph-settings-page-display">
-        <location filename="../qml/pages/SettingsPage.qml" line="170"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="175"/>
         <source>Display</source>
         <translation>显示</translation>
     </message>
+    <message id="ph-settings-page-display-videos-per-grid-row">
+        <location filename="../qml/pages/SettingsPage.qml" line="182"/>
+        <source>Videos per row</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="ph-settings-page-display-categories-per-grid-row">
-        <location filename="../qml/pages/SettingsPage.qml" line="177"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="207"/>
         <source>Categories per row</source>
         <translation>每列分类</translation>
     </message>
     <message id="ph-settings-page-display-pornstars-per-grid-row">
-        <location filename="../qml/pages/SettingsPage.qml" line="202"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="232"/>
         <source>Pornstars per row</source>
         <translation>每列情色影星</translation>
     </message>
+    <message id="ph-settings-page-display-extra-landscape-column">
+        <location filename="../qml/pages/SettingsPage.qml" line="255"/>
+        <source>Add one extra column in landscape orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="ph-settings-page-access">
-        <location filename="../qml/pages/SettingsPage.qml" line="225"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="265"/>
         <source>Access</source>
         <translation>访问</translation>
     </message>
     <message id="ph-settings-page-access-restrict-text">
-        <location filename="../qml/pages/SettingsPage.qml" line="230"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="270"/>
         <source>Require a PIN to access the app</source>
         <translation>需要PIN 码以访问应用程序</translation>
     </message>
     <message id="ph-settings-page-access-restrict-description">
-        <location filename="../qml/pages/SettingsPage.qml" line="232"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="272"/>
         <source>Protect against accidently accessing the application. The PIN will be stored as plain text in the application configuration directory. Should you forget your PIN simply delete the file to restore access to the application.</source>
         <translation>防止意外访问应用程序。PIN 将以纯文本形式存储在应用程序配置目录中。 如果你忘记了PIN，只需删除该文件即可恢复对该应用程序的访问权限。</translation>
     </message>
     <message id="ph-settings-page-access-require-pin-label">
-        <location filename="../qml/pages/SettingsPage.qml" line="248"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="288"/>
         <source>PIN</source>
         <translation>PIN</translation>
     </message>
     <message id="ph-settings-page-access-require-pin-placeholder">
-        <location filename="../qml/pages/SettingsPage.qml" line="250"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="290"/>
         <source>Enter four or more digits</source>
         <translation>请输入四位及以上数字</translation>
     </message>
     <message id="ph-settings-page-access-lock-screen-text">
-        <location filename="../qml/pages/SettingsPage.qml" line="265"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="305"/>
         <source>Lock screen text</source>
         <translation>锁屏文本</translation>
     </message>
     <message id="ph-settings-page-account">
-        <location filename="../qml/pages/SettingsPage.qml" line="278"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="318"/>
         <source>Account</source>
         <translation>账户</translation>
     </message>
     <message id="ph-settings-page-account-username">
-        <location filename="../qml/pages/SettingsPage.qml" line="283"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="323"/>
         <source>Username</source>
         <translation>用户名</translation>
     </message>
     <message id="ph-settings-page-account-auto-login">
-        <location filename="../qml/pages/SettingsPage.qml" line="309"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="349"/>
         <source>Login on application start</source>
         <translation>应用程序启动时自动登录</translation>
     </message>
     <message id="ph-about-page-header">
-        <location filename="../qml/pages/AboutPage.qml" line="42"/>
+        <location filename="../qml/pages/AboutPage.qml" line="47"/>
         <source>About %1</source>
         <translation>关于 %1</translation>
     </message>
     <message id="ph-about-page-version-text">
-        <location filename="../qml/pages/AboutPage.qml" line="90"/>
+        <location filename="../qml/pages/AboutPage.qml" line="95"/>
         <source>%1 %2</source>
         <translation>%1 %2</translation>
     </message>
     <message id="ph-about-page-description-header">
-        <location filename="../qml/pages/AboutPage.qml" line="107"/>
+        <location filename="../qml/pages/AboutPage.qml" line="112"/>
         <source>Description</source>
         <translation>描述</translation>
     </message>
     <message id="ph-about-page-description-text">
-        <location filename="../qml/pages/AboutPage.qml" line="114"/>
+        <location filename="../qml/pages/AboutPage.qml" line="119"/>
         <source>%1 is an unofficial Sailfish OS client for the adult content website &lt;a href=&apos;https://www.pornhub.com/&apos;&gt;Pornhub&lt;/a&gt;.</source>
         <translation>%1 是一个非官方旗鱼系统 Pornhub客户端&lt;a href=&apos;https://www.pornhub.com/&apos;&gt;Pornhub&lt;/a&gt;.</translation>
     </message>
     <message id="about-page-disclaimer-header">
-        <location filename="../qml/pages/AboutPage.qml" line="123"/>
+        <location filename="../qml/pages/AboutPage.qml" line="128"/>
         <source>Disclaimer</source>
         <translation>免责声明</translation>
     </message>
     <message id="ph-about-page-disclaimer-text">
-        <location filename="../qml/pages/AboutPage.qml" line="130"/>
+        <location filename="../qml/pages/AboutPage.qml" line="135"/>
         <source>The content provided through %1 is the property and sole responsibility of &lt;a href=&apos;https://www.pornhub.com/&apos;&gt;Pornhub&lt;/a&gt;.</source>
         <translation>内容由 %1 提供并享有一切权利及承担一切义务 &lt;a href=&apos;https://www.pornhub.com/&apos;&gt;Pornhub&lt;/a&gt;.</translation>
     </message>
     <message id="about-page-credits-licenses-sources-header">
-        <location filename="../qml/pages/AboutPage.qml" line="139"/>
+        <location filename="../qml/pages/AboutPage.qml" line="144"/>
         <source>Credits, Licenses, and Sources</source>
         <translation>信誉、许可协议及源代码</translation>
     </message>
     <message id="ph-about-page-credits-licenses-sources-text">
-        <location filename="../qml/pages/AboutPage.qml" line="146"/>
+        <location filename="../qml/pages/AboutPage.qml" line="151"/>
         <source>Copyright © 2019 grumpycat&lt;br/&gt;&lt;br/&gt;This application is available under the MIT licence on &lt;a href=&apos;https://github.com/grumpycat3051/harbour-phillis/&apos;&gt;Github&lt;/a&gt;. %1 uses icons made by Smashicons from &lt;a href=&apos;https://www.flaticon.com/&apos;&gt;flaticon&lt;/a&gt;.</source>
         <oldsource>Copyright © 2019 grumpycat&lt;br/&gt;&lt;br/&gt;This application is available under the MIT licence on &lt;a href=&apos;https://github.com/grumpycat3051/harbour-phillis/&apos;&gt;Github&lt;/a&gt;.&lt;br/&gt;%1 uses icons made by Smashicons from &lt;a href=&apos;https://www.flaticon.com/&apos;&gt;flaticon&lt;/a&gt;.</oldsource>
         <translation>​版权所有 © 2019 grumpycat&lt;br/&gt;&lt;br/&gt;该软件在  MIT 许可证下发布 &lt;a href=&apos;https://github.com/grumpycat3051/harbour-phillis/&apos;&gt;Github&lt;/a&gt;. %1 使用 Smashicons 制作的图标 &lt;a href=&apos;https://www.flaticon.com/&apos;&gt;flaticon&lt;/a&gt;。</translation>
     </message>
     <message id="ph-about-privacy-header">
-        <location filename="../qml/pages/AboutPage.qml" line="168"/>
+        <location filename="../qml/pages/AboutPage.qml" line="173"/>
         <source>Privacy</source>
         <translation>隐私政策</translation>
     </message>
     <message id="ph-about-page-privacy-text">
-        <location filename="../qml/pages/AboutPage.qml" line="175"/>
+        <location filename="../qml/pages/AboutPage.qml" line="180"/>
         <source>This application does not collect or save any personal data aside from possibly those credentials required to sign into &lt;a href=&apos;https://www.pornhub.com/&apos;&gt;Pornhub&lt;/a&gt;.</source>
         <translation>该软件不会收集及储存你的任何个人信息，尽管需要凭证以登录到  &lt;a href=&apos;https://www.pornhub.com/&apos;&gt;Pornhub&lt;/a&gt;.</translation>
     </message>
     <message id="about-page-translations-button">
-        <location filename="../qml/pages/AboutPage.qml" line="161"/>
+        <location filename="../qml/pages/AboutPage.qml" line="166"/>
         <source>Translations</source>
         <translation>翻译</translation>
     </message>
     <message id="ph-categories-page-filter-placeholder">
-        <location filename="../qml/pages/CategoriesPage.qml" line="115"/>
+        <location filename="../qml/pages/CategoriesPage.qml" line="117"/>
         <source>Filter</source>
         <translation>筛选</translation>
     </message>
     <message id="ph-categories-page-view-placeholder-text-loading">
-        <location filename="../qml/pages/CategoriesPage.qml" line="203"/>
+        <location filename="../qml/pages/CategoriesPage.qml" line="205"/>
         <source>Categories are being loaded</source>
         <translation>正在加载分类</translation>
     </message>
     <message id="ph-push-up-menu-load-more">
-        <location filename="../qml/pages/PornstarsPage.qml" line="114"/>
-        <location filename="../qml/pages/VideosPage.qml" line="93"/>
+        <location filename="../qml/pages/PornstarsPage.qml" line="116"/>
+        <location filename="../qml/pages/VideosPage.qml" line="97"/>
         <source>Load more</source>
         <translation>加载更多</translation>
     </message>
     <message id="ph-pornstars-page-view-placeholder-text-loading">
-        <location filename="../qml/pages/PornstarsPage.qml" line="172"/>
+        <location filename="../qml/pages/PornstarsPage.qml" line="174"/>
         <source>Pornstars are being loaded</source>
         <translation>正在加载情色明星</translation>
     </message>
     <message id="ph-view-placeholder-text-no-results">
-        <location filename="../qml/pages/PornstarsPage.qml" line="177"/>
-        <location filename="../qml/pages/VideosPage.qml" line="200"/>
+        <location filename="../qml/pages/PornstarsPage.qml" line="179"/>
+        <location filename="../qml/pages/VideosPage.qml" line="207"/>
         <source>Search yielded no results</source>
         <translation>无搜索结果</translation>
     </message>
     <message id="ph-videos-page-context-menu-copy-url-to-clipboard">
-        <location filename="../qml/pages/VideosPage.qml" line="123"/>
+        <location filename="../qml/pages/VideosPage.qml" line="130"/>
         <source>Copy URL to clipboard</source>
         <translation>复制链接到剪切板</translation>
     </message>
     <message id="ph-videos-page-view-placeholder-text-loading">
-        <location filename="../qml/pages/VideosPage.qml" line="195"/>
+        <location filename="../qml/pages/VideosPage.qml" line="202"/>
         <source>Videos are being loaded</source>
         <translation>正在加载视频</translation>
     </message>
     <message id="ph-disclaimer-page-title">
-        <location filename="../qml/pages/AdultContentDisclaimerPage.qml" line="57"/>
+        <location filename="../qml/pages/AdultContentDisclaimerPage.qml" line="60"/>
         <source>Adult Content Disclaimer</source>
         <translation>成人内容声明</translation>
     </message>
     <message id="ph-disclaimer-page-text1">
-        <location filename="../qml/pages/AdultContentDisclaimerPage.qml" line="70"/>
+        <location filename="../qml/pages/AdultContentDisclaimerPage.qml" line="73"/>
         <source>The content provided through this app is designed for ADULTS only and may include pictures and materials that some viewers may find offensive. If you are under the age of 18, if such material offends you or if it is illegal to view such material in your community please exit the site. The following terms and conditions apply to this site. Use of the site will constitute your agreement to the following terms and conditions:</source>
         <translation>此应用程序提供的内容仅适用于成年人，可能包含一些观众会觉得冒犯的图片和材料。 如果你未满18岁或者此类材料冒犯您或者您所在社区查看此类材料是非法的，请退出该网站。 以下条款和条件适用于本网站。 使用本网站即表示您同意以下条款和条件:</translation>
     </message>
     <message id="ph-disclaimer-page-text2">
-        <location filename="../qml/pages/AdultContentDisclaimerPage.qml" line="83"/>
+        <location filename="../qml/pages/AdultContentDisclaimerPage.qml" line="86"/>
         <source>1.) I am 18 years of age or older&lt;br/&gt;2.) I accept all responsibility for my own actions; and&lt;br/&gt;3.) I agree that I am legally bound to these Terms and Conditions</source>
         <translation>1.我已年满18岁 2.我对自己的行为负全部责任 3.我同意我在法律上受这些条款和条件的约束</translation>
     </message>
     <message id="ph-disclaimer-page-accept-button">
-        <location filename="../qml/pages/AdultContentDisclaimerPage.qml" line="98"/>
+        <location filename="../qml/pages/AdultContentDisclaimerPage.qml" line="101"/>
         <source>Accept</source>
         <translation>接受</translation>
     </message>
     <message id="ph-lock-screen-page-pin-placeholder">
-        <location filename="../qml/pages/LockScreenPage.qml" line="65"/>
+        <location filename="../qml/pages/LockScreenPage.qml" line="66"/>
         <source>PIN</source>
         <translation>PIN</translation>
     </message>
     <message id="ph-recommended-page-header">
-        <location filename="../qml/pages/RecommendedPage.qml" line="133"/>
+        <location filename="../qml/pages/RecommendedPage.qml" line="134"/>
         <source>Recommended</source>
         <translation>推荐</translation>
     </message>
     <message id="ph-recommended-page-pornstars-section-header">
-        <location filename="../qml/pages/RecommendedPage.qml" line="139"/>
+        <location filename="../qml/pages/RecommendedPage.qml" line="140"/>
         <source>Pornstars</source>
         <translation>情色明星</translation>
     </message>
     <message id="ph-recommended-page-categories-section-header">
-        <location filename="../qml/pages/RecommendedPage.qml" line="202"/>
+        <location filename="../qml/pages/RecommendedPage.qml" line="203"/>
         <source>Categories</source>
         <translation>分类</translation>
     </message>
     <message id="ph-start-page-videos-hottest">
-        <location filename="../qml/pages/StartPage.qml" line="46"/>
+        <location filename="../qml/pages/StartPage.qml" line="47"/>
         <source>Hottest</source>
         <translation>最火</translation>
     </message>
     <message id="ph-start-page-videos-most-viewed">
-        <location filename="../qml/pages/StartPage.qml" line="53"/>
+        <location filename="../qml/pages/StartPage.qml" line="54"/>
         <source>Most Viewed</source>
         <translation>最多浏览</translation>
     </message>
     <message id="ph-start-page-videos-top-ratedmost-viewed">
-        <location filename="../qml/pages/StartPage.qml" line="60"/>
+        <location filename="../qml/pages/StartPage.qml" line="61"/>
         <source>Top Rated</source>
         <translation>最高评分</translation>
     </message>
     <message id="ph-start-page-videos-popular-homemade">
-        <location filename="../qml/pages/StartPage.qml" line="67"/>
+        <location filename="../qml/pages/StartPage.qml" line="68"/>
         <source>Popular Homemade</source>
         <translation>最流行家庭制作</translation>
     </message>
     <message id="ph-start-page-categories-popular">
-        <location filename="../qml/pages/StartPage.qml" line="77"/>
+        <location filename="../qml/pages/StartPage.qml" line="78"/>
         <source>Popular</source>
         <translation>最流行</translation>
     </message>
     <message id="ph-start-page-categories-alphabetical">
-        <location filename="../qml/pages/StartPage.qml" line="84"/>
+        <location filename="../qml/pages/StartPage.qml" line="85"/>
         <source>Alphabetical</source>
         <translation>按字母表排序</translation>
     </message>
     <message id="ph-start-page-categories-no-videos">
-        <location filename="../qml/pages/StartPage.qml" line="91"/>
+        <location filename="../qml/pages/StartPage.qml" line="92"/>
         <source>Number of Videos</source>
         <translation>视频编号</translation>
     </message>
     <message id="ph-start-page-pornstars-most-popular">
-        <location filename="../qml/pages/StartPage.qml" line="101"/>
+        <location filename="../qml/pages/StartPage.qml" line="102"/>
         <source>Most Popular</source>
         <translation>最受欢迎</translation>
     </message>
     <message id="ph-start-page-pornstars-top-trending">
-        <location filename="../qml/pages/StartPage.qml" line="108"/>
+        <location filename="../qml/pages/StartPage.qml" line="109"/>
         <source>Top Trending</source>
         <translation>流行趋势</translation>
     </message>
     <message id="ph-start-page-pornstars-most-viewed">
-        <location filename="../qml/pages/StartPage.qml" line="115"/>
+        <location filename="../qml/pages/StartPage.qml" line="116"/>
         <source>Most Viewed</source>
         <translation>最多浏览</translation>
     </message>
     <message id="ph-start-page-pornstars-most-subscribed">
-        <location filename="../qml/pages/StartPage.qml" line="122"/>
+        <location filename="../qml/pages/StartPage.qml" line="123"/>
         <source>Most Subscribed</source>
         <translation>最多订阅</translation>
     </message>
     <message id="ph-start-page-pornstars-no-videos">
-        <location filename="../qml/pages/StartPage.qml" line="136"/>
+        <location filename="../qml/pages/StartPage.qml" line="137"/>
         <source>Number of Videos</source>
         <translation>视频编号</translation>
     </message>
     <message id="ph-start-page-header">
-        <location filename="../qml/pages/StartPage.qml" line="192"/>
+        <location filename="../qml/pages/StartPage.qml" line="197"/>
         <source>Pornhub</source>
         <translation>Pornhub</translation>
     </message>
     <message id="ph-start-page-videos-recommended">
-        <location filename="../qml/pages/StartPage.qml" line="197"/>
+        <location filename="../qml/pages/StartPage.qml" line="202"/>
         <source>Recommended</source>
         <translation>推荐</translation>
     </message>
     <message id="ph-start-page-videos-section-title">
-        <location filename="../qml/pages/StartPage.qml" line="210"/>
+        <location filename="../qml/pages/StartPage.qml" line="215"/>
         <source>Videos</source>
         <translation>视频</translation>
     </message>
     <message id="ph-start-page-search-placeholder">
-        <location filename="../qml/pages/StartPage.qml" line="234"/>
-        <location filename="../qml/pages/StartPage.qml" line="300"/>
+        <location filename="../qml/pages/StartPage.qml" line="239"/>
+        <location filename="../qml/pages/StartPage.qml" line="305"/>
         <source>Search</source>
         <translation>搜索</translation>
     </message>
     <message id="ph-start-page-categories-section-title">
-        <location filename="../qml/pages/StartPage.qml" line="251"/>
+        <location filename="../qml/pages/StartPage.qml" line="256"/>
         <source>Categories</source>
         <translation>分类</translation>
     </message>
     <message id="ph-start-page-pornstars-section-title">
-        <location filename="../qml/pages/StartPage.qml" line="276"/>
+        <location filename="../qml/pages/StartPage.qml" line="281"/>
         <source>Pornstars</source>
         <translation>情色明星</translation>
     </message>
     <message id="ph-start-page-my-section-title">
-        <location filename="../qml/pages/StartPage.qml" line="317"/>
+        <location filename="../qml/pages/StartPage.qml" line="322"/>
         <source>My</source>
         <translation>我的</translation>
     </message>
     <message id="ph-start-page-user-videos-favorites">
-        <location filename="../qml/pages/StartPage.qml" line="352"/>
+        <location filename="../qml/pages/StartPage.qml" line="357"/>
         <source>Favorites</source>
         <translation>收藏</translation>
     </message>
@@ -419,42 +429,42 @@
         <translation>%1&apos;s 视频</translation>
     </message>
     <message id="ph-translations-page-header">
-        <location filename="../qml/pages/TranslationsPage.qml" line="41"/>
+        <location filename="../qml/pages/TranslationsPage.qml" line="46"/>
         <source>Translations</source>
         <translation>翻译</translation>
     </message>
     <message id="ph-translations-page-english-label">
-        <location filename="../qml/pages/TranslationsPage.qml" line="55"/>
+        <location filename="../qml/pages/TranslationsPage.qml" line="60"/>
         <source>English</source>
         <translation>英语</translation>
     </message>
     <message id="ph-translations-page-simplified-chinese-label">
-        <location filename="../qml/pages/TranslationsPage.qml" line="61"/>
+        <location filename="../qml/pages/TranslationsPage.qml" line="66"/>
         <source>Simplified Chinese</source>
         <translation>汉语（简体）</translation>
     </message>
     <message id="ph-translations-page-italian-label">
-        <location filename="../qml/pages/TranslationsPage.qml" line="67"/>
+        <location filename="../qml/pages/TranslationsPage.qml" line="72"/>
         <source>Italian</source>
         <translation>意大利语</translation>
     </message>
     <message id="ph-login-succes-message">
-        <location filename="../qml/harbour-phillis.qml" line="81"/>
+        <location filename="../qml/harbour-phillis.qml" line="83"/>
         <source>Login success</source>
         <translation>登录成功</translation>
     </message>
     <message id="ph-error-message-initial-request-failed">
-        <location filename="../qml/harbour-phillis.qml" line="118"/>
+        <location filename="../qml/harbour-phillis.qml" line="120"/>
         <source>Initial loading of website failed</source>
         <translation>初始化加载网页失败</translation>
     </message>
     <message id="ph-setting-lock-screen-text">
-        <location filename="../qml/harbour-phillis.qml" line="229"/>
+        <location filename="../qml/harbour-phillis.qml" line="243"/>
         <source>Please enter your online trading PIN</source>
         <translation>请输入你的在线验证码</translation>
     </message>
     <message id="ph-error-request-failed-summary">
-        <location filename="../qml/harbour-phillis.qml" line="345"/>
+        <location filename="../qml/harbour-phillis.qml" line="357"/>
         <source>Request failed</source>
         <translation>请求失败</translation>
     </message>

--- a/translations/harbour-phillis-zh_CN.ts
+++ b/translations/harbour-phillis-zh_CN.ts
@@ -448,6 +448,11 @@
         <source>Italian</source>
         <translation>意大利语</translation>
     </message>
+    <message id="ph-translations-page-finnish-label">
+        <location filename="../qml/pages/TranslationsPage.qml" line="78"/>
+        <source>Finnish</source>
+        <translation type="unfinished">芬兰语</translation>
+    </message>
     <message id="ph-login-succes-message">
         <location filename="../qml/harbour-phillis.qml" line="83"/>
         <source>Login success</source>

--- a/translations/harbour-phillis.ts
+++ b/translations/harbour-phillis.ts
@@ -4,371 +4,381 @@
 <context>
     <name></name>
     <message id="ph-settings-page-header">
-        <location filename="../qml/pages/SettingsPage.qml" line="47"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="52"/>
         <source>Settings</source>
         <translation>Settings</translation>
     </message>
     <message id="ph-settings-page-network-header">
-        <location filename="../qml/pages/SettingsPage.qml" line="52"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="57"/>
         <source>Network</source>
         <translation>Network</translation>
     </message>
     <message id="ph-settings-page-network-connection-type">
-        <location filename="../qml/pages/SettingsPage.qml" line="59"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="64"/>
         <source>Network connection type</source>
         <translation>Network connection type</translation>
     </message>
     <message id="ph-settings-page-network-connection-autodetect">
-        <location filename="../qml/pages/SettingsPage.qml" line="63"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="68"/>
         <source>Autodetect</source>
         <translation>Autodetect</translation>
     </message>
     <message id="ph-settings-page-network-connection-broadband">
-        <location filename="../qml/pages/SettingsPage.qml" line="67"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="72"/>
         <source>Broadband</source>
         <translation>Broadband</translation>
     </message>
     <message id="ph-settings-page-network-connection-mobile">
-        <location filename="../qml/pages/SettingsPage.qml" line="71"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="76"/>
         <source>Mobile</source>
         <translation>Mobile</translation>
     </message>
     <message id="ph-format-label">
-        <location filename="../qml/pages/SettingsPage.qml" line="85"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="90"/>
         <source>Format</source>
         <translation>Format</translation>
     </message>
     <message id="ph-settings-page-network-broadband-label">
-        <location filename="../qml/pages/SettingsPage.qml" line="90"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="95"/>
         <source>Broadband</source>
         <translation>Broadband</translation>
     </message>
     <message id="ph-settings-page-network-mobile-label">
-        <location filename="../qml/pages/SettingsPage.qml" line="104"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="109"/>
         <source>Mobile</source>
         <translation>Mobile</translation>
     </message>
     <message id="ph-settings-page-content-preferences-section-header">
-        <location filename="../qml/pages/SettingsPage.qml" line="118"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="123"/>
         <source>Content Preferences</source>
         <translation>Content Preferences</translation>
     </message>
     <message id="ph-settings-page-content-preferences-gay-only-switch-text">
-        <location filename="../qml/pages/SettingsPage.qml" line="127"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="132"/>
         <source>Gay Only</source>
         <translation>Gay Only</translation>
     </message>
     <message id="ph-settings-page-content-preferences-gay-only-switch-description">
-        <location filename="../qml/pages/SettingsPage.qml" line="129"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="134"/>
         <source>Only show gay categories and videos</source>
         <translation>Only show gay categories and videos</translation>
     </message>
     <message id="ph-settings-page-playback-section-header">
-        <location filename="../qml/pages/SettingsPage.qml" line="145"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="150"/>
         <source>Playback</source>
         <translation>Playback</translation>
     </message>
     <message id="ph-settings-page-playback-pause-on-device-lock-switch">
-        <location filename="../qml/pages/SettingsPage.qml" line="150"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="155"/>
         <source>Pause playback on device lock</source>
         <translation>Pause playback on device lock</translation>
     </message>
     <message id="ph-settings-page-playback-pause-if-cover-page-switch">
-        <location filename="../qml/pages/SettingsPage.qml" line="160"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="165"/>
         <source>Pause playback when the cover page is shown</source>
         <translation>Pause playback when the cover page is shown</translation>
     </message>
     <message id="ph-settings-page-display">
-        <location filename="../qml/pages/SettingsPage.qml" line="170"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="175"/>
         <source>Display</source>
         <translation>Display</translation>
     </message>
+    <message id="ph-settings-page-display-videos-per-grid-row">
+        <location filename="../qml/pages/SettingsPage.qml" line="182"/>
+        <source>Videos per row</source>
+        <translation>Videos per row</translation>
+    </message>
     <message id="ph-settings-page-display-categories-per-grid-row">
-        <location filename="../qml/pages/SettingsPage.qml" line="177"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="207"/>
         <source>Categories per row</source>
         <translation>Categories per row</translation>
     </message>
     <message id="ph-settings-page-display-pornstars-per-grid-row">
-        <location filename="../qml/pages/SettingsPage.qml" line="202"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="232"/>
         <source>Pornstars per row</source>
         <translation>Pornstars per row</translation>
     </message>
+    <message id="ph-settings-page-display-extra-landscape-column">
+        <location filename="../qml/pages/SettingsPage.qml" line="255"/>
+        <source>Add one extra column in landscape orientation</source>
+        <translation>Add one extra column in landscape orientation</translation>
+    </message>
     <message id="ph-settings-page-access">
-        <location filename="../qml/pages/SettingsPage.qml" line="225"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="265"/>
         <source>Access</source>
         <translation>Access</translation>
     </message>
     <message id="ph-settings-page-access-restrict-text">
-        <location filename="../qml/pages/SettingsPage.qml" line="230"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="270"/>
         <source>Require a PIN to access the app</source>
         <translation>Require a PIN to access the application</translation>
     </message>
     <message id="ph-settings-page-access-restrict-description">
-        <location filename="../qml/pages/SettingsPage.qml" line="232"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="272"/>
         <source>Protect against accidently accessing the application. The PIN will be stored as plain text in the application configuration directory. Should you forget your PIN simply delete the file to restore access to the application.</source>
         <translation>Protect against accidently accessing the application. The PIN will be stored as plain text in the application configuration directory. Should you forget your PIN simply delete the file to restore access to the application.</translation>
     </message>
     <message id="ph-settings-page-access-require-pin-label">
-        <location filename="../qml/pages/SettingsPage.qml" line="248"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="288"/>
         <source>PIN</source>
         <translation>PIN</translation>
     </message>
     <message id="ph-settings-page-access-require-pin-placeholder">
-        <location filename="../qml/pages/SettingsPage.qml" line="250"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="290"/>
         <source>Enter four or more digits</source>
         <translation>Enter four or more digits</translation>
     </message>
     <message id="ph-settings-page-access-lock-screen-text">
-        <location filename="../qml/pages/SettingsPage.qml" line="265"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="305"/>
         <source>Lock screen text</source>
         <translation>Lock screen text</translation>
     </message>
     <message id="ph-settings-page-account">
-        <location filename="../qml/pages/SettingsPage.qml" line="278"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="318"/>
         <source>Account</source>
         <translation>Account</translation>
     </message>
     <message id="ph-settings-page-account-username">
-        <location filename="../qml/pages/SettingsPage.qml" line="283"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="323"/>
         <source>Username</source>
         <translation>Username</translation>
     </message>
     <message id="ph-settings-page-account-auto-login">
-        <location filename="../qml/pages/SettingsPage.qml" line="309"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="349"/>
         <source>Login on application start</source>
         <translation>Login on application start</translation>
     </message>
     <message id="ph-about-page-header">
-        <location filename="../qml/pages/AboutPage.qml" line="42"/>
+        <location filename="../qml/pages/AboutPage.qml" line="47"/>
         <source>About %1</source>
         <translation>About %1</translation>
     </message>
     <message id="ph-about-page-version-text">
-        <location filename="../qml/pages/AboutPage.qml" line="90"/>
+        <location filename="../qml/pages/AboutPage.qml" line="95"/>
         <source>%1 %2</source>
         <translation>%1 %2</translation>
     </message>
     <message id="ph-about-page-description-header">
-        <location filename="../qml/pages/AboutPage.qml" line="107"/>
+        <location filename="../qml/pages/AboutPage.qml" line="112"/>
         <source>Description</source>
         <translation>Description</translation>
     </message>
     <message id="ph-about-page-description-text">
-        <location filename="../qml/pages/AboutPage.qml" line="114"/>
+        <location filename="../qml/pages/AboutPage.qml" line="119"/>
         <source>%1 is an unofficial Sailfish OS client for the adult content website &lt;a href=&apos;https://www.pornhub.com/&apos;&gt;Pornhub&lt;/a&gt;.</source>
         <translation>%1 is an unofficial Sailfish OS client for the adult content website &lt;a href=&apos;https://www.pornhub.com/&apos;&gt;Pornhub&lt;/a&gt;.</translation>
     </message>
     <message id="about-page-disclaimer-header">
-        <location filename="../qml/pages/AboutPage.qml" line="123"/>
+        <location filename="../qml/pages/AboutPage.qml" line="128"/>
         <source>Disclaimer</source>
         <translation>Disclaimer</translation>
     </message>
     <message id="ph-about-page-disclaimer-text">
-        <location filename="../qml/pages/AboutPage.qml" line="130"/>
+        <location filename="../qml/pages/AboutPage.qml" line="135"/>
         <source>The content provided through %1 is the property and sole responsibility of &lt;a href=&apos;https://www.pornhub.com/&apos;&gt;Pornhub&lt;/a&gt;.</source>
         <translation>The content provided through %1 is the property and sole responsibility of &lt;a href=&apos;https://www.pornhub.com/&apos;&gt;Pornhub&lt;/a&gt;.</translation>
     </message>
     <message id="about-page-credits-licenses-sources-header">
-        <location filename="../qml/pages/AboutPage.qml" line="139"/>
+        <location filename="../qml/pages/AboutPage.qml" line="144"/>
         <source>Credits, Licenses, and Sources</source>
         <translation>Credits, Licenses, and Sources</translation>
     </message>
     <message id="ph-about-page-credits-licenses-sources-text">
-        <location filename="../qml/pages/AboutPage.qml" line="146"/>
+        <location filename="../qml/pages/AboutPage.qml" line="151"/>
         <source>Copyright © 2019 grumpycat&lt;br/&gt;&lt;br/&gt;This application is available under the MIT licence on &lt;a href=&apos;https://github.com/grumpycat3051/harbour-phillis/&apos;&gt;Github&lt;/a&gt;. %1 uses icons made by Smashicons from &lt;a href=&apos;https://www.flaticon.com/&apos;&gt;flaticon&lt;/a&gt;.</source>
         <oldsource>Copyright © 2019 grumpycat&lt;br/&gt;&lt;br/&gt;This application is available under the MIT licence on &lt;a href=&apos;https://github.com/grumpycat3051/harbour-phillis/&apos;&gt;Github&lt;/a&gt;.&lt;br/&gt;%1 uses icons made by Smashicons from &lt;a href=&apos;https://www.flaticon.com/&apos;&gt;flaticon&lt;/a&gt;.</oldsource>
         <translation>Copyright © 2019 grumpycat&lt;br/&gt;&lt;br/&gt;This application is available under the MIT licence on &lt;a href=&apos;https://github.com/grumpycat3051/harbour-phillis/&apos;&gt;Github&lt;/a&gt;. %1 uses icons made by Smashicons from &lt;a href=&apos;https://www.flaticon.com/&apos;&gt;flaticon&lt;/a&gt;.</translation>
     </message>
     <message id="ph-about-privacy-header">
-        <location filename="../qml/pages/AboutPage.qml" line="168"/>
+        <location filename="../qml/pages/AboutPage.qml" line="173"/>
         <source>Privacy</source>
         <translation>Privacy</translation>
     </message>
     <message id="ph-about-page-privacy-text">
-        <location filename="../qml/pages/AboutPage.qml" line="175"/>
+        <location filename="../qml/pages/AboutPage.qml" line="180"/>
         <source>This application does not collect or save any personal data aside from possibly those credentials required to sign into &lt;a href=&apos;https://www.pornhub.com/&apos;&gt;Pornhub&lt;/a&gt;.</source>
         <translation>This application does not collect or save any personal data aside from possibly those credentials required to sign into &lt;a href=&apos;https://www.pornhub.com/&apos;&gt;Pornhub&lt;/a&gt;.</translation>
     </message>
     <message id="about-page-translations-button">
-        <location filename="../qml/pages/AboutPage.qml" line="161"/>
+        <location filename="../qml/pages/AboutPage.qml" line="166"/>
         <source>Translations</source>
         <translation>Translations</translation>
     </message>
     <message id="ph-categories-page-filter-placeholder">
-        <location filename="../qml/pages/CategoriesPage.qml" line="115"/>
+        <location filename="../qml/pages/CategoriesPage.qml" line="117"/>
         <source>Filter</source>
         <translation>Filter</translation>
     </message>
     <message id="ph-categories-page-view-placeholder-text-loading">
-        <location filename="../qml/pages/CategoriesPage.qml" line="203"/>
+        <location filename="../qml/pages/CategoriesPage.qml" line="205"/>
         <source>Categories are being loaded</source>
         <translation>Categories are being loaded</translation>
     </message>
     <message id="ph-push-up-menu-load-more">
-        <location filename="../qml/pages/PornstarsPage.qml" line="114"/>
-        <location filename="../qml/pages/VideosPage.qml" line="93"/>
+        <location filename="../qml/pages/PornstarsPage.qml" line="116"/>
+        <location filename="../qml/pages/VideosPage.qml" line="97"/>
         <source>Load more</source>
         <translation>Load more</translation>
     </message>
     <message id="ph-pornstars-page-view-placeholder-text-loading">
-        <location filename="../qml/pages/PornstarsPage.qml" line="172"/>
+        <location filename="../qml/pages/PornstarsPage.qml" line="174"/>
         <source>Pornstars are being loaded</source>
         <translation>Pornstars are being loaded</translation>
     </message>
     <message id="ph-view-placeholder-text-no-results">
-        <location filename="../qml/pages/PornstarsPage.qml" line="177"/>
-        <location filename="../qml/pages/VideosPage.qml" line="200"/>
+        <location filename="../qml/pages/PornstarsPage.qml" line="179"/>
+        <location filename="../qml/pages/VideosPage.qml" line="207"/>
         <source>Search yielded no results</source>
         <translation>Search yielded no results</translation>
     </message>
     <message id="ph-videos-page-context-menu-copy-url-to-clipboard">
-        <location filename="../qml/pages/VideosPage.qml" line="123"/>
+        <location filename="../qml/pages/VideosPage.qml" line="130"/>
         <source>Copy URL to clipboard</source>
         <translation>Copy URL to clipboard</translation>
     </message>
     <message id="ph-videos-page-view-placeholder-text-loading">
-        <location filename="../qml/pages/VideosPage.qml" line="195"/>
+        <location filename="../qml/pages/VideosPage.qml" line="202"/>
         <source>Videos are being loaded</source>
         <translation>Videos are being loaded</translation>
     </message>
     <message id="ph-disclaimer-page-title">
-        <location filename="../qml/pages/AdultContentDisclaimerPage.qml" line="57"/>
+        <location filename="../qml/pages/AdultContentDisclaimerPage.qml" line="60"/>
         <source>Adult Content Disclaimer</source>
         <translation>Adult Content Disclaimer</translation>
     </message>
     <message id="ph-disclaimer-page-text1">
-        <location filename="../qml/pages/AdultContentDisclaimerPage.qml" line="70"/>
+        <location filename="../qml/pages/AdultContentDisclaimerPage.qml" line="73"/>
         <source>The content provided through this app is designed for ADULTS only and may include pictures and materials that some viewers may find offensive. If you are under the age of 18, if such material offends you or if it is illegal to view such material in your community please exit the site. The following terms and conditions apply to this site. Use of the site will constitute your agreement to the following terms and conditions:</source>
         <translation>The content provided through this app is designed for ADULTS only and may include pictures and materials that some viewers may find offensive. If you are under the age of 18, if such material offends you or if it is illegal to view such material in your community please exit the site. The following terms and conditions apply to this site. Use of the site will constitute your agreement to the following terms and conditions:</translation>
     </message>
     <message id="ph-disclaimer-page-text2">
-        <location filename="../qml/pages/AdultContentDisclaimerPage.qml" line="83"/>
+        <location filename="../qml/pages/AdultContentDisclaimerPage.qml" line="86"/>
         <source>1.) I am 18 years of age or older&lt;br/&gt;2.) I accept all responsibility for my own actions; and&lt;br/&gt;3.) I agree that I am legally bound to these Terms and Conditions</source>
         <translation>1.) I am 18 years of age or older&lt;br/&gt;2.) I accept all responsibility for my own actions; and&lt;br/&gt;3.) I agree that I am legally bound to these Terms and Conditions</translation>
     </message>
     <message id="ph-disclaimer-page-accept-button">
-        <location filename="../qml/pages/AdultContentDisclaimerPage.qml" line="98"/>
+        <location filename="../qml/pages/AdultContentDisclaimerPage.qml" line="101"/>
         <source>Accept</source>
         <translation>Accept</translation>
     </message>
     <message id="ph-lock-screen-page-pin-placeholder">
-        <location filename="../qml/pages/LockScreenPage.qml" line="65"/>
+        <location filename="../qml/pages/LockScreenPage.qml" line="66"/>
         <source>PIN</source>
         <translation>PIN</translation>
     </message>
     <message id="ph-recommended-page-header">
-        <location filename="../qml/pages/RecommendedPage.qml" line="133"/>
+        <location filename="../qml/pages/RecommendedPage.qml" line="134"/>
         <source>Recommended</source>
         <translation>Recommended</translation>
     </message>
     <message id="ph-recommended-page-pornstars-section-header">
-        <location filename="../qml/pages/RecommendedPage.qml" line="139"/>
+        <location filename="../qml/pages/RecommendedPage.qml" line="140"/>
         <source>Pornstars</source>
         <translation>Pornstars</translation>
     </message>
     <message id="ph-recommended-page-categories-section-header">
-        <location filename="../qml/pages/RecommendedPage.qml" line="202"/>
+        <location filename="../qml/pages/RecommendedPage.qml" line="203"/>
         <source>Categories</source>
         <translation>Categories</translation>
     </message>
     <message id="ph-start-page-videos-hottest">
-        <location filename="../qml/pages/StartPage.qml" line="46"/>
+        <location filename="../qml/pages/StartPage.qml" line="47"/>
         <source>Hottest</source>
         <translation>Hottest</translation>
     </message>
     <message id="ph-start-page-videos-most-viewed">
-        <location filename="../qml/pages/StartPage.qml" line="53"/>
+        <location filename="../qml/pages/StartPage.qml" line="54"/>
         <source>Most Viewed</source>
         <translation>Most Viewed</translation>
     </message>
     <message id="ph-start-page-videos-top-ratedmost-viewed">
-        <location filename="../qml/pages/StartPage.qml" line="60"/>
+        <location filename="../qml/pages/StartPage.qml" line="61"/>
         <source>Top Rated</source>
         <translation>Top Rated</translation>
     </message>
     <message id="ph-start-page-videos-popular-homemade">
-        <location filename="../qml/pages/StartPage.qml" line="67"/>
+        <location filename="../qml/pages/StartPage.qml" line="68"/>
         <source>Popular Homemade</source>
         <translation>Popular Homemade</translation>
     </message>
     <message id="ph-start-page-categories-popular">
-        <location filename="../qml/pages/StartPage.qml" line="77"/>
+        <location filename="../qml/pages/StartPage.qml" line="78"/>
         <source>Popular</source>
         <translation>Popular</translation>
     </message>
     <message id="ph-start-page-categories-alphabetical">
-        <location filename="../qml/pages/StartPage.qml" line="84"/>
+        <location filename="../qml/pages/StartPage.qml" line="85"/>
         <source>Alphabetical</source>
         <translation>Alphabetical</translation>
     </message>
     <message id="ph-start-page-categories-no-videos">
-        <location filename="../qml/pages/StartPage.qml" line="91"/>
+        <location filename="../qml/pages/StartPage.qml" line="92"/>
         <source>Number of Videos</source>
         <translation>Number of Videos</translation>
     </message>
     <message id="ph-start-page-pornstars-most-popular">
-        <location filename="../qml/pages/StartPage.qml" line="101"/>
+        <location filename="../qml/pages/StartPage.qml" line="102"/>
         <source>Most Popular</source>
         <translation>Most Popular</translation>
     </message>
     <message id="ph-start-page-pornstars-top-trending">
-        <location filename="../qml/pages/StartPage.qml" line="108"/>
+        <location filename="../qml/pages/StartPage.qml" line="109"/>
         <source>Top Trending</source>
         <translation>Top Trending</translation>
     </message>
     <message id="ph-start-page-pornstars-most-viewed">
-        <location filename="../qml/pages/StartPage.qml" line="115"/>
+        <location filename="../qml/pages/StartPage.qml" line="116"/>
         <source>Most Viewed</source>
         <translation>Most Viewed</translation>
     </message>
     <message id="ph-start-page-pornstars-most-subscribed">
-        <location filename="../qml/pages/StartPage.qml" line="122"/>
+        <location filename="../qml/pages/StartPage.qml" line="123"/>
         <source>Most Subscribed</source>
         <translation>Most Subscribed</translation>
     </message>
     <message id="ph-start-page-pornstars-no-videos">
-        <location filename="../qml/pages/StartPage.qml" line="136"/>
+        <location filename="../qml/pages/StartPage.qml" line="137"/>
         <source>Number of Videos</source>
         <translation>Number of Videos</translation>
     </message>
     <message id="ph-start-page-header">
-        <location filename="../qml/pages/StartPage.qml" line="192"/>
+        <location filename="../qml/pages/StartPage.qml" line="197"/>
         <source>Pornhub</source>
         <translation>Pornhub</translation>
     </message>
     <message id="ph-start-page-videos-recommended">
-        <location filename="../qml/pages/StartPage.qml" line="197"/>
+        <location filename="../qml/pages/StartPage.qml" line="202"/>
         <source>Recommended</source>
         <translation>Recommended</translation>
     </message>
     <message id="ph-start-page-videos-section-title">
-        <location filename="../qml/pages/StartPage.qml" line="210"/>
+        <location filename="../qml/pages/StartPage.qml" line="215"/>
         <source>Videos</source>
         <translation>Videos</translation>
     </message>
     <message id="ph-start-page-search-placeholder">
-        <location filename="../qml/pages/StartPage.qml" line="234"/>
-        <location filename="../qml/pages/StartPage.qml" line="300"/>
+        <location filename="../qml/pages/StartPage.qml" line="239"/>
+        <location filename="../qml/pages/StartPage.qml" line="305"/>
         <source>Search</source>
         <translation>Search</translation>
     </message>
     <message id="ph-start-page-categories-section-title">
-        <location filename="../qml/pages/StartPage.qml" line="251"/>
+        <location filename="../qml/pages/StartPage.qml" line="256"/>
         <source>Categories</source>
         <translation>Categories</translation>
     </message>
     <message id="ph-start-page-pornstars-section-title">
-        <location filename="../qml/pages/StartPage.qml" line="276"/>
+        <location filename="../qml/pages/StartPage.qml" line="281"/>
         <source>Pornstars</source>
         <translation>Pornstars</translation>
     </message>
     <message id="ph-start-page-my-section-title">
-        <location filename="../qml/pages/StartPage.qml" line="317"/>
+        <location filename="../qml/pages/StartPage.qml" line="322"/>
         <source>My</source>
         <translation>My</translation>
     </message>
     <message id="ph-start-page-user-videos-favorites">
-        <location filename="../qml/pages/StartPage.qml" line="352"/>
+        <location filename="../qml/pages/StartPage.qml" line="357"/>
         <source>Favorites</source>
         <translation>Favorites</translation>
     </message>
@@ -419,42 +429,42 @@
         <translation>%1&apos;s Videos</translation>
     </message>
     <message id="ph-translations-page-header">
-        <location filename="../qml/pages/TranslationsPage.qml" line="41"/>
+        <location filename="../qml/pages/TranslationsPage.qml" line="46"/>
         <source>Translations</source>
         <translation>Translations</translation>
     </message>
     <message id="ph-translations-page-english-label">
-        <location filename="../qml/pages/TranslationsPage.qml" line="55"/>
+        <location filename="../qml/pages/TranslationsPage.qml" line="60"/>
         <source>English</source>
         <translation>English</translation>
     </message>
     <message id="ph-translations-page-simplified-chinese-label">
-        <location filename="../qml/pages/TranslationsPage.qml" line="61"/>
+        <location filename="../qml/pages/TranslationsPage.qml" line="66"/>
         <source>Simplified Chinese</source>
         <translation>Simplified Chinese</translation>
     </message>
     <message id="ph-translations-page-italian-label">
-        <location filename="../qml/pages/TranslationsPage.qml" line="67"/>
+        <location filename="../qml/pages/TranslationsPage.qml" line="72"/>
         <source>Italian</source>
         <translation>Italian</translation>
     </message>
     <message id="ph-login-succes-message">
-        <location filename="../qml/harbour-phillis.qml" line="81"/>
+        <location filename="../qml/harbour-phillis.qml" line="83"/>
         <source>Login success</source>
         <translation>Login success</translation>
     </message>
     <message id="ph-error-message-initial-request-failed">
-        <location filename="../qml/harbour-phillis.qml" line="118"/>
+        <location filename="../qml/harbour-phillis.qml" line="120"/>
         <source>Initial loading of website failed</source>
         <translation>Initial loading of website failed</translation>
     </message>
     <message id="ph-setting-lock-screen-text">
-        <location filename="../qml/harbour-phillis.qml" line="229"/>
+        <location filename="../qml/harbour-phillis.qml" line="243"/>
         <source>Please enter your online trading PIN</source>
         <translation>Please enter your online trading PIN</translation>
     </message>
     <message id="ph-error-request-failed-summary">
-        <location filename="../qml/harbour-phillis.qml" line="345"/>
+        <location filename="../qml/harbour-phillis.qml" line="357"/>
         <source>Request failed</source>
         <translation>Request failed</translation>
     </message>

--- a/translations/harbour-phillis.ts
+++ b/translations/harbour-phillis.ts
@@ -448,6 +448,11 @@
         <source>Italian</source>
         <translation>Italian</translation>
     </message>
+    <message id="ph-translations-page-finnish-label">
+        <location filename="../qml/pages/TranslationsPage.qml" line="78"/>
+        <source>Finnish</source>
+        <translation>Finnish</translation>
+    </message>
     <message id="ph-login-succes-message">
         <location filename="../qml/harbour-phillis.qml" line="83"/>
         <source>Login success</source>


### PR DESCRIPTION
Hello,

I tested PHillis with my Sony Xperia Z3 Compact Tablet and noticed that the application didn't support landscape mode at all, so I added that. Then I noticed that the video thumbnails were almost horribly large and hence very pixelated, so I implemented a grid view and its setting. Then I fiddled around with dynamic row count (it was suspiciously easy...), and decided to implement an option for it, too. And, finally, while I was at it, I translated the application in Finnish.

I tested the layouts with my tablet and Sony Xperia XA2 Ultra, and they seem to work fine. The only "issue" is that if the items per row count doesn't divide number of results, there are one or more "empty slots" at the end of the page, but that is unavoidable (afaik).

Thanks!